### PR TITLE
Rename logback.xml and make it log to file

### DIFF
--- a/conf/ds-datahandler.logback.xml
+++ b/conf/ds-datahandler.logback.xml
@@ -1,7 +1,7 @@
 <included>
     <contextName>ds-datahandler</contextName>
 
-    <property name="LOGFILE" value="${catalina.home}/logs/template-app.log" />
+    <property name="LOGFILE" value="${catalina.home}/logs/ds-datahandler.log" />
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOGFILE}</file>
@@ -20,7 +20,7 @@
     </appender>
 
     <root level="INFO">
-      <appender-ref ref="STDOUT" />
+      <appender-ref ref="FILE" />
     </root>
     <logger name="dk.kb" level="DEBUG" />
  


### PR DESCRIPTION
Prepending the artifact to logback.xml makes it clear which project it belongs to, when deployed to a server with multiple services.

Concurrently support has been added to [aegis](https://github.com/kb-dk/aegis/) so that `kb deploy devel` works for `ds-datahandler`.