### PR TITLE
Change logging for ZIP upload to log the full recordId instead of just the UUID

### DIFF
--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -65,7 +65,7 @@ public class DsDatahandlerFacade {
                 identifier=identifier.replaceFirst("urn:uuid:", ""); // Clear this first part from the ID
                 
                 String recordId= recordBase+":"+identifier;
-                log.info("Ingesting record filename from zip:"+fileName +" id:"+identifier);
+                log.info("Ingesting record filename from zip:"+fileName +" id:"+recordId);
                 DsRecordDto dsRecord = new DsRecordDto();
                 dsRecord.setId(recordId); 
                 dsRecord.setBase(recordBase);


### PR DESCRIPTION
Extremely small pull request: Simple log change to show the full recordId when ingesting a record, for easier copy-pasting when debugging