### PR TITLE
Rename radiotv-base and fix OpenAPI-problem

### DIFF
--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -101,14 +101,14 @@ config:
       set: oai:kb.dk:manus:vmanus:2011:dec:ha
       metadataPrefix: mods
       description: Vesterlandske håndskrifter
-    - name: pvica.devel
+    - name: ds.radiotv
       # Internal information for pvica.devel is provided by internal config files
-      recordBase: pvica
+      recordBase: ds.radiotv
       url: https://XXXXXXXXX.statsbiblioteket.dk/OAI-PMH/
       user: XXXXXXXXX
       password: XXXXXXXXX
       metadataPrefix: XIP_full_schema
-      description: pvica devel 
+      description: Radio- og TV-udsendelser
       
                     
   # Save timestamps of last OAI harvest for each target in this folder. This is used for incremental delta-imports.                

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -100,11 +100,12 @@ config:
       url: http://www5.kb.dk/cop/oai/
       set: oai:kb.dk:manus:vmanus:2011:dec:ha
       metadataPrefix: mods
-      description: Vesterlandske håndskrifter            
+      description: Vesterlandske håndskrifter
     - name: pvica.devel
+      # Internal information for pvica.devel is provided by internal config files
       recordBase: pvica
-      url: https://pvica-devel2.statsbiblioteket.dk/OAI-PMH/
-      user: oai-pmh-devel
+      url: https://XXXXXXXXX.statsbiblioteket.dk/OAI-PMH/
+      user: XXXXXXXXX
       password: XXXXXXXXX
       metadataPrefix: XIP_full_schema
       description: pvica devel 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.12</version>
+            <version>1.4.14</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->
@@ -513,7 +513,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.build.outputDirectory}/ds-datahandler_v1.yaml</inputSpec>
+                            <inputSpec>${project.build.outputDirectory}/ds-datahandler-openapi_v1.yaml</inputSpec>
                             <ignoreFileOverride>
                                 ${project.basedir}/.openapi-codegen-ignore-api
                             </ignoreFileOverride>
@@ -537,7 +537,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.build.outputDirectory}/ds-datahandler_v1.yaml</inputSpec>
+                            <inputSpec>${project.build.outputDirectory}/ds-datahandler-openapi_v1.yaml</inputSpec>
                             <ignoreFileOverride>
                                 ${project.basedir}/.openapi-codegen-ignore-impl
                             </ignoreFileOverride>
@@ -616,7 +616,7 @@
                         </manifest>
                     </archive>
 
-                    <!--This is really just to get an artifact containing openapi_ds-datahandler_v1.yaml-->
+                    <!--This is really just to get an artifact containing ds-datahandler-openapi_v1.yaml-->
                     <attachClasses>true</attachClasses>
 
                     <!--Enable maven filtering for the web.xml-->

--- a/pom.xml
+++ b/pom.xml
@@ -463,8 +463,7 @@
                      which seems to be an unresolved issue: https://github.com/OpenAPITools/openapi-generator/issues/9008 -->
                 <configuration>
                     <generatorName>jaxrs-cxf-extended</generatorName>
-                    <inputSpec>${project.build.outputDirectory}/openapi.yaml
-                    </inputSpec><!-- Will always be overridden -->
+                    <inputSpec>${project.build.outputDirectory}/openapi.yaml</inputSpec><!-- Will always be overridden -->
                     <modelNameSuffix>Dto</modelNameSuffix>
                     <generateSupportingFiles>false</generateSupportingFiles>
                     <generateApiTests>false</generateApiTests>
@@ -634,8 +633,8 @@
                             <directory>${project.build.outputDirectory}</directory>
                             <targetPath>.</targetPath>
                             <includes>
-                                <include>ds-datatahandler_v1.json</include>
-                                <include>ds-datatahandler_v1.yaml</include>
+                                <include>ds-datahandler-openapi_v1.json</include>
+                                <include>ds-datahandler-openapi_v1.yaml</include>
                             </includes>
                         </resource>
                     </webResources>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -29,7 +29,7 @@
             <!--THIS IS A HACK. But it seems like the simplest way to recover the original specs-->
             <param-name>static-resources-list</param-name>
             <param-value>
-                /ds-datahandler_.*\..+
+                /ds-datahandler-openapi_.*\..+
             </param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>

--- a/src/main/webapp/api/index.html
+++ b/src/main/webapp/api/index.html
@@ -40,7 +40,7 @@
       // Begin Swagger UI call region
       // https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
       const ui = SwaggerUIBundle({
-        urls: [ { url: "/ds-datahandler/v1/ds-datahandler_v1.yaml", name: "ds-datahandler API v1"}
+        urls: [ { url: "/ds-datahandler/v1/ds-datahandler-openapi_v1.yaml", name: "ds-datahandler API v1"}
                 // Add API-YAMLs below when creating a new version
                 //, { url: "/ds-datahandler/devel/openapi_v2.yaml", name: "ds-datahandler API v2"}
         ],


### PR DESCRIPTION
This pull request renames the  `pvica.devel`-base to the more telling `ds.radiotv` and fixes an unrelated bug where renaming of the OpenAPI YAML causes a missing file.