### PR TITLE
Disc 282 storage2solr

### DIFF
--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -117,11 +117,14 @@ config:
   # The ds-storage server to ingest data into 
   storage:
     url: http://localhost:9072/ds-storage/v1    
+
+  # solr. Used by workflow that extracts from storage, xslt and index into solr.  
+  solr:
+    url:  http://localhost:10011/solr/ds/update
   
-  # Indexing to solr
-  index:
-    dsPresentUrl:  http://localhost:9073/ds-present/v1  
-    solrUrl:  http://localhost:10011/solr/ds/update
+  # The ds-present server used for xslt
+  present:
+    url: http://localhost:9073/ds-present/v1
     
     
       

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -117,5 +117,11 @@ config:
   # The ds-storage server to ingest data into 
   storage:
     url: http://localhost:9072/ds-storage/v1    
+  
+  # Indexing to solr
+  index:
+    dsPresentUrl:  http://localhost:9073/ds-present/v1  
+    solrUrl:  http://localhost:10011/solr/ds/update
+    
     
       

--- a/pom.xml
+++ b/pom.xml
@@ -131,23 +131,6 @@
         </exclusions>
       </dependency>
         
-
-     <!-- Client for ds-present This will also require the org.openapitools dependency-->     
-     <!-- NOT USED YET. Because client does not return streaming output -->
-      <dependency>
-        <groupId>dk.kb.present</groupId>
-        <artifactId>ds-present</artifactId>
-          <version>1.0</version>
-          <type>jar</type>
-          <classifier>classes</classifier>
-          <exclusions>
-            <exclusion>
-              <groupId>*</groupId>
-              <artifactId>*</artifactId>
-            </exclusion>
-        </exclusions>
-      </dependency>
-        
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     |                  | The origin must be configured in DS-storage. ID will be {origin}:{id in OAI record}                       |
     | description      | Human text to give further description if needed                                                          |
     
-  
     ## Full import and delta import
     For each OAI target configured you can request a full import or a delta import from the OAI collection. A full import will
     harvest all records from to OAI target. A delta import will only import records with a datestamp later than the last record
@@ -132,6 +131,22 @@
         </exclusions>
       </dependency>
         
+
+     <!-- Client for ds-present This will also require the org.openapitools dependency-->     
+     <!-- NOT USED YET. Because client does not return streaming output -->
+      <dependency>
+        <groupId>dk.kb.present</groupId>
+        <artifactId>ds-present</artifactId>
+          <version>1.0</version>
+          <type>jar</type>
+          <classifier>classes</classifier>
+          <exclusions>
+            <exclusion>
+              <groupId>*</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+        </exclusions>
+      </dependency>
         
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/src/main/java/dk/kb/datahandler/api/v1/impl/DsDatahandlerApiServiceImpl.java
+++ b/src/main/java/dk/kb/datahandler/api/v1/impl/DsDatahandlerApiServiceImpl.java
@@ -15,6 +15,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Request;
@@ -125,6 +126,17 @@ public class DsDatahandlerApiServiceImpl extends ImplBase implements DsDatahandl
         }  catch (Exception e){
             throw handleException(e);
         }
+    }
+
+    @Override
+    public void solrIndex(String solrUrl) {
+        log.debug("solrIndex(solrUrl='{}', ...) called with call details: {}", solrUrl, getCallDetails());
+        try {            
+            DsDatahandlerFacade.indexSolr(solrUrl);
+        }  catch (Exception e){
+            throw handleException(e);
+        }
+        
     }
 
 }

--- a/src/main/java/dk/kb/datahandler/api/v1/impl/DsDatahandlerApiServiceImpl.java
+++ b/src/main/java/dk/kb/datahandler/api/v1/impl/DsDatahandlerApiServiceImpl.java
@@ -129,10 +129,10 @@ public class DsDatahandlerApiServiceImpl extends ImplBase implements DsDatahandl
     }
 
     @Override
-    public void solrIndex(String solrUrl) {
-        log.debug("solrIndex(solrUrl='{}', ...) called with call details: {}", solrUrl, getCallDetails());
+    public void solrIndex(String origin) {
+        log.debug("solrIndex(origin='{}', ...) called with call details: {}", origin, getCallDetails());
         try {            
-            DsDatahandlerFacade.indexSolr(solrUrl);
+            DsDatahandlerFacade.indexSolr(origin);
         }  catch (Exception e){
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -47,8 +47,8 @@ public class ServiceConfig {
         
         oaiTimestampFolder= serviceConfig.getString("config.timestamps.folder");
         dsStorageUrl = serviceConfig.getString("config.storage.url");
-        solrUrl = serviceConfig.getString("config.index.solrUrl");
-        dsPresentUrl = serviceConfig.getString("config.index.dsPresentUrl");
+        solrUrl = serviceConfig.getString("config.solr.url");
+        dsPresentUrl = serviceConfig.getString("config.present.url");
         
         Path folderPath = Paths.get(oaiTimestampFolder);
         if (Files.exists(folderPath)) {            

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -24,6 +24,9 @@ public class ServiceConfig {
     private static final HashMap<String, OaiTargetDto> oaiTargets = new HashMap<String, OaiTargetDto>();
     private static String oaiTimestampFolder=null;
     private static String dsStorageUrl = null;
+    private static String solrUrl = null;
+    private static String dsPresentUrl = null;
+    
     
     /**
      * Besides parsing of YAML files using SnakeYAML, the YAML helper class provides convenience
@@ -44,7 +47,8 @@ public class ServiceConfig {
         
         oaiTimestampFolder= serviceConfig.getString("config.timestamps.folder");
         dsStorageUrl = serviceConfig.getString("config.storage.url");
-     
+        solrUrl = serviceConfig.getString("config.index.solrUrl");
+        dsPresentUrl = serviceConfig.getString("config.index.dsPresentUrl");
         
         Path folderPath = Paths.get(oaiTimestampFolder);
         if (Files.exists(folderPath)) {            
@@ -70,6 +74,15 @@ public class ServiceConfig {
             throw new IllegalStateException("The configuration should have been loaded, but was not");
         }
         return serviceConfig;
+    }
+
+
+    public static String getSolrUrl() {
+        return solrUrl;
+    }
+    
+    public static String getDsPresentUrl() {
+        return dsPresentUrl;
     }
 
     public static String getDsStorageUrl() {

--- a/src/main/java/dk/kb/datahandler/util/HttpPostUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HttpPostUtil.java
@@ -1,0 +1,60 @@
+package dk.kb.datahandler.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+
+/**
+ *  Util class for doing POST request with an InputStream so it is not loaded into memory
+ *  Can it be done easier with apacheIO ?  
+ */
+
+public class HttpPostUtil {
+        
+    public static String callPost(HttpURLConnection conn, InputStream input) throws IOException {
+        conn.setRequestMethod("POST");
+        conn.setConnectTimeout(30 * 1000);
+        conn.setReadTimeout(30 * 1000);
+        conn.setUseCaches(false);
+
+        if (input != null) {
+            conn.setDoOutput(true);
+
+            OutputStream out = conn.getOutputStream();
+
+            byte[] data = new byte[1024];
+            int read = 0;
+            while ((read = input.read(data, 0, data.length)) != -1) {
+                out.write(data, 0, read);
+            }
+
+            input.close();
+            out.flush();
+            out.close();
+        } else {
+            conn.connect();
+        }
+
+        InputStream is = null;
+
+        try {
+            is = conn.getInputStream();
+        } catch (IOException e) {
+            is = conn.getErrorStream();
+        }
+
+        StringBuilder buf = new StringBuilder();
+        BufferedReader in = new BufferedReader(new InputStreamReader(is,"UTF-8"));
+        String inputLine;
+        while ((inputLine = in.readLine()) != null) {
+            buf.append(inputLine);
+        }
+        in.close();
+
+        return buf.toString();
+    }
+}
+

--- a/src/main/java/dk/kb/datahandler/util/HttpPostUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HttpPostUtil.java
@@ -14,17 +14,29 @@ import java.net.HttpURLConnection;
 
 public class HttpPostUtil {
         
-    public static String callPost(HttpURLConnection conn, InputStream input) throws IOException {
+    
+    /**
+     * Takes an InputStream and feeds it to a HTTP post request
+     * 
+     * 
+     * @param conn Connected data will be posted to
+     * @param input Stream having json data
+     * @param contentType. Example :  'application/json'
+     * @return Response string from server.
+     * @throws IOException
+     */
+    
+    
+    public static String callPost(HttpURLConnection conn, InputStream input, String contentType) throws IOException {
+        conn.setRequestProperty("Content-Type", contentType);
         conn.setRequestMethod("POST");
-        conn.setConnectTimeout(30 * 1000);
-        conn.setReadTimeout(30 * 1000);
+        conn.setConnectTimeout(30 * 1000); //30 secs
+        conn.setReadTimeout(60 * 1000); // 10 minutes 600 secs. Maybe large load needs to be delivered.
         conn.setUseCaches(false);
-
-        if (input != null) {
-            conn.setDoOutput(true);
-
-            OutputStream out = conn.getOutputStream();
-
+        conn.setDoOutput(true);
+        
+        try (input ; OutputStream out = conn.getOutputStream()){
+            
             byte[] data = new byte[1024];
             int read = 0;
             while ((read = input.read(data, 0, data.length)) != -1) {
@@ -34,27 +46,19 @@ public class HttpPostUtil {
             input.close();
             out.flush();
             out.close();
-        } else {
-            conn.connect();
         }
-
-        InputStream is = null;
-
-        try {
-            is = conn.getInputStream();
-        } catch (IOException e) {
-            is = conn.getErrorStream();
-        }
-
-        StringBuilder buf = new StringBuilder();
-        BufferedReader in = new BufferedReader(new InputStreamReader(is,"UTF-8"));
-        String inputLine;
-        while ((inputLine = in.readLine()) != null) {
+        
+        try (InputStream is = conn.getInputStream()){              
+          StringBuilder buf = new StringBuilder();
+          BufferedReader in = new BufferedReader(new InputStreamReader(is,"UTF-8"));
+          String inputLine;
+          while ((inputLine = in.readLine()) != null) {
             buf.append(inputLine);
-        }
-        in.close();
+          }
+          in.close();
 
-        return buf.toString();
+          return buf.toString();
+        }
     }
 }
 

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -112,7 +112,7 @@ paths:
     get:
       tags:
         - '${project.name}'
-      summary: 'Will start indexing workflow that will read records from ds-storage, xslt transform them in ds-present and post the documents to solr'
+      summary: 'Will start indexing workflow that will read records from ds-storage, xslt transform them in ds-present and post the documents to solr. There is a hardcoded limit of 100.000 documents maximum'
       operationId: solrIndex
       parameters:
         - name: dsPresentCollectionName

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -108,16 +108,16 @@ paths:
                 
                
                 
-  /solr/index/:
+  /solr/index/full:
     get:
       tags:
         - '${project.name}'
       summary: 'Will start indexing workflow that will read records from ds-storage, xslt transform them in ds-present and post the documents to solr. There is a hardcoded limit of 100.000 documents maximum'
       operationId: solrIndex
       parameters:
-        - name: dsPresentCollectionName
+        - name: origin
           in: query
-          description: 'Will call ds-present for solr-records that will be posted to solr. This collection name must be defined in the ds-present configuration'
+          description: 'Will call ds-present for solr-records that will be posted to solr. Origin must be defined in the ds-present configuration'
           required: true
           schema:
             type: string     

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -104,7 +104,28 @@ paths:
             application/json:
               schema:
                 type: integer
-                format: int32      
+                format: int32
+                
+               
+                
+  /solr/index/:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Will start indexing workflow that will read records from ds-storage, xslt transform them in ds-present and post the documents to solr'
+      operationId: solrIndex
+      parameters:
+        - name: dsPresentCollectionName
+          in: query
+          description: 'Will call ds-present for solr-records that will be posted to solr. This collection name must be defined in the ds-present configuration'
+          required: true
+          schema:
+            type: string     
+                         
+      responses:
+        '200':
+          description: OK.               
+                      
 
   # The ping service should be in all projects, should not do any advanced processing
   # and should respond quickly with a simple message, e.g. "pong".


### PR DESCRIPTION
Workflow calling ds-present that will call ds-storage and xslt-transform the documents into solr documents.
The call is not done by openAPI client since it does not return an inputstream.

The input stream is given directly to a POST request to the solr-server so it is not in memory.

The unused ds-present  client is added to the pom.xml and sample code is uncommented.
