### PR TITLE
After a full ingest, delete old records in storage that are earlier than

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <dependency>
         <groupId>dk.kb.storage</groupId>
         <artifactId>ds-storage</artifactId>
-          <version>1.5</version>
+          <version>1.8</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/src/main/java/dk/kb/datahandler/oai/OaiHarvestClient.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiHarvestClient.java
@@ -81,7 +81,7 @@ public class OaiHarvestClient {
         String  resumptionToken=  getResumptionToken(document);
         oaiResponse.setTotalRecords(getResumptionTotalSize(document));        
 
-        if (resumptionToken != null) {
+        if (resumptionToken != null && !resumptionToken.equals("")) {
             this.resumptionToken = resumptionToken;  
             oaiResponse.setResumptionToken(resumptionToken);
         }

--- a/src/main/java/dk/kb/datahandler/oai/OaiResponseFiltering.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiResponseFiltering.java
@@ -55,11 +55,15 @@ public class OaiResponseFiltering {
 
     /**
      * Define RecordType from id.
+     * For Pvica posts all 3 values can be defined.
+     * For OAI records from other collections such is images, the default will be RecordTypeDto.DELIVERABLEUNIT.
+     * 
+     * 
      * @param dsRecord to specify recordType for.
      * @param storageId used to define the type of record.
      */
     public static void setRecordType(DsRecordDto dsRecord, String storageId) {
-        if (storageId.contains("oai:col")){
+    	if (storageId.contains("oai:col")){
             dsRecord.setRecordType(RecordTypeDto.COLLECTION);
         } else if (storageId.contains("oai:du")) {
             dsRecord.setRecordType(RecordTypeDto.DELIVERABLEUNIT);

--- a/src/main/java/dk/kb/datahandler/oai/OaiResponseFiltering.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiResponseFiltering.java
@@ -66,6 +66,9 @@ public class OaiResponseFiltering {
         } else if (storageId.contains("oai:man")) {
             dsRecord.setRecordType(RecordTypeDto.MANIFESTATION);
         }
+        else {
+            dsRecord.setRecordType(RecordTypeDto.DELIVERABLEUNIT);
+        }
     }
 
     

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -65,7 +65,7 @@ paths:
     get:
       tags:
         - '${project.name}'
-      summary: 'Start full ingest of a OAI target into DS-storage. From time will be 1900-01-01. When called the job will finished if no errors are encountered even if the socket is closed from the client triggering the call.'
+      summary: 'Start full ingest of a OAI target into DS-storage. From time will be 1900-01-01. When called the job will finished if no errors are encountered even if the socket is closed from the client triggering the call. After full ingest ds-storage will be called again and all older recorders from before the ingest fill be deleted.'
       operationId: oaiIngestFull
       parameters:
         - name: oaiTarget


### PR DESCRIPTION
After a full ingest, delete old records in storage that are earlier than those ingested. Doing this AFTER the ingest and not before, will mean that the storage will be functionable during the ingest.