### PR TITLE
Simulated OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Pvica authentication now also uses basic authentication using headers. The callback authentication is still active, but will not be called from pvica6
 - Use FormatDTO for SOLRJSON format when calling ds-present
+- Preliminary support for token based user group resolving, preparing for OAuth2
 
 
 ## [1.4.0](https://github.com/kb-dk/ds-datahandler/releases/tag/v1.4.0) - 2023-12-05

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -159,6 +159,11 @@ solr:
 # The ds-present server used for xslt
 present:
   url: http://localhost:9073/ds-present/v1
-  
+  headers:
+    # This is not security!
+    # This is used for establishing token flows using HTTP headers un preparation of OAuth2 support
+    # Set this to internal_service to bypass the ds-license based access server
+    - Simulated-OAuth2-Group: anonymous
+
     
       

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.19-SNAPSHOT</version>
+            <version>1.4.19</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->
@@ -134,7 +134,7 @@
       <dependency>
         <groupId>dk.kb.present</groupId>
         <artifactId>ds-present</artifactId>
-          <version>1.2.2-SNAPSHOT</version>
+          <version>1.2.2</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.18</version>
+            <version>1.4.19-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->
@@ -134,7 +134,7 @@
       <dependency>
         <groupId>dk.kb.present</groupId>
         <artifactId>ds-present</artifactId>
-          <version>1.2.1</version>
+          <version>1.2.2-SNAPSHOT</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -1,5 +1,27 @@
 package dk.kb.datahandler.facade;
 
+import dk.kb.datahandler.config.ServiceConfig;
+import dk.kb.datahandler.model.v1.OaiJobDto;
+import dk.kb.datahandler.model.v1.OaiTargetDto;
+import dk.kb.datahandler.oai.*;
+import dk.kb.datahandler.util.HarvestTimeUtil;
+import dk.kb.datahandler.util.HttpPostUtil;
+import dk.kb.present.model.v1.FormatDto;
+import dk.kb.present.util.DsPresentClient;
+import dk.kb.storage.client.v1.DsStorageApi;
+import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.OriginCountDto;
+import dk.kb.storage.util.DsStorageClient;
+import dk.kb.util.webservice.exception.InternalServiceException;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
+import dk.kb.util.webservice.stream.ContinuationInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,34 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-
-import dk.kb.datahandler.oai.*;
-import org.apache.http.client.utils.URIBuilder;
-
-import dk.kb.util.webservice.exception.InternalServiceException;
-import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
-import dk.kb.util.webservice.stream.ContinuationInputStream;
-
-import org.apache.commons.io.IOUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-
-
-import dk.kb.datahandler.config.ServiceConfig;
-import dk.kb.datahandler.model.v1.OaiJobDto;
-import dk.kb.datahandler.model.v1.OaiTargetDto;
-import dk.kb.datahandler.util.HarvestTimeUtil;
-import dk.kb.datahandler.util.HttpPostUtil;
-import dk.kb.present.model.v1.FormatDto;
-import dk.kb.present.util.DsPresentClient;
-import dk.kb.storage.client.v1.DsStorageApi;
-import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.OriginCountDto;
-import dk.kb.storage.util.DsStorageClient;
 
 
 public class DsDatahandlerFacade {
@@ -113,7 +107,7 @@ public class DsDatahandlerFacade {
         }
         
         //Define the 2 clients. Inputstream from dsPresent will be feed direcly to the solrClient. 
-        DsPresentClient presentClient = new DsPresentClient(ServiceConfig.getDsPresentUrl());
+        DsPresentClient presentClient = new DsPresentClient(ServiceConfig.getConfig());
         URL solrUpdateUrl=new URIBuilder(ServiceConfig.getSolrUrl())
             .setParameter("commit", "true")
             .build().toURL();      


### PR DESCRIPTION
With HTTP simulated authentication token support added to `ds-present`, `ds-datahandler` should also have that enabled.

This pull request adds a tiny bit of code for sending the `Simulated-OAuth2-Group: internal_service` header. This is synchronized with `aegis` being updated to set the header for the devel deploy of `ds-datahandler`.

Also, and sorry for the messy unmess, there are multiple minor corrections to log calls. The only real code change is [line 111 in DsDatahandlerFacade](https://github.com/kb-dk/ds-datahandler/compare/DISC-542_simulate_oauth?expand=1#diff-abd474d163b4b58635205cdccde637a799dfcaa3c814c60aa758b57498ea75faR111).