### PR TITLE
Disc 775 pvica oai from until day only

### DIFF
--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -10,7 +10,7 @@
 #
 
 # List of oai targets
-oai_targets:
+oaiTargets:
   - name: kb.letters.judsam.dsa
     datasource: kb.letters.judsam.dsa
     url: http://www5.kb.dk/cop/oai/
@@ -140,7 +140,7 @@ oai_targets:
     metadataPrefix: XIP_full_schema
     description: Radio- og TV-udsendelser
     filter: preservica
-    oai_daily: true
+    oaiDaily: true
 
 
 

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -17,7 +17,7 @@ oai_targets:
     set: oai:kb.dk:letters:judsam:2011:mar:dsa
     metadataPrefix: mods
     description: David Simonsens Arkiv
-    filter: direct
+    filter: direct    
 
   - name: kb.image.judsam.jsmss
     datasource: kb.image.judsam.jsmss
@@ -140,6 +140,7 @@ oai_targets:
     metadataPrefix: XIP_full_schema
     description: Radio- og TV-udsendelser
     filter: preservica
+    oai_daily: true
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,21 +183,7 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.3.5</version>
-            <!--<version>3.4.0</version>-->
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <!-- cxf-rt-transports-http has 1.2.0, but transitive resolving has 1.2.2 somewhere-->
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>javax.activation</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+        </dependency>      
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -677,14 +677,7 @@
                 </executions>
                 <configuration>
                     <filePath>conf/ds-datahandler-behaviour.yaml</filePath>
-                    <yamlResolvers>
-                        <YamlResolver>
-                            <yamlType>List</yamlType>
-                            <yamlPath>oai_targets</yamlPath>
-                            <sourceKey>name</sourceKey>
-                            <destinationKey>oai_targets</destinationKey>
-                            <createEnum>true</createEnum>
-                        </YamlResolver>
+                    <yamlResolvers>                    
                         <yamlResolver>
                             <yamlType>List</yamlType>
                             <yamlPath>present.origins</yamlPath>

--- a/src/main/java/dk/kb/datahandler/api/v1/impl/DsDatahandlerApiServiceImpl.java
+++ b/src/main/java/dk/kb/datahandler/api/v1/impl/DsDatahandlerApiServiceImpl.java
@@ -86,7 +86,8 @@ public class DsDatahandlerApiServiceImpl extends ImplBase implements DsDatahandl
         }
 
     }
-
+    
+    @Override
     public Integer oaiIngestDelta(String oaiTarget){
         log.debug("oaiIngestDelta(oaiTarget='{}') called with call details: {}", oaiTarget, getCallDetails());
         try {

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dk.kb.datahandler.model.v1.OaiTargetDto;
+import dk.kb.datahandler.util.HarvestTimeUtil;
 import dk.kb.util.yaml.YAML;
 
 /**
@@ -124,6 +125,15 @@ public class ServiceConfig {
             String user=target.getString("user",null);
             String password=target.getString("password",null);
             String filterStr = target.getString("filter","direct");
+            Boolean dayOnly = target.getBoolean("day_only",Boolean.FALSE);
+        	String startDay = target.getString("start_day",null);            
+            if (dayOnly) { //startDay must be defined for datOnly strategy                        	      
+            	boolean validStartDay=HarvestTimeUtil.validateDayFormat(startDay);
+                if (!validStartDay) {
+                 	throw new IllegalArgumentException("Failed to parse startDate for OAI target with dayOnly strategy. Day="+startDay);
+                }            	
+            }
+            
             OaiTargetDto.FilterEnum filter;
             try {
                 filter = OaiTargetDto.FilterEnum.fromValue(filterStr);
@@ -143,6 +153,8 @@ public class ServiceConfig {
             oaiTarget.setDatasource(datasource);
             oaiTarget.setDecription(description);
             oaiTarget.setFilter(filter);
+            oaiTarget.setDayOnly(dayOnly);
+            oaiTarget.setStartDay(startDay);
             oaiTargets.put(name, oaiTarget);
             
             log.info("Load OAI target from yaml:"+name);

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -115,7 +115,7 @@ public class ServiceConfig {
 
     
     private static void loadOaiTargets() {
-        List<YAML> targets = serviceConfig.getYAMLList("oai_targets");
+        List<YAML> targets = serviceConfig.getYAMLList("oaiTargets");
         for (YAML target: targets) {
             String name = target.getString("name");
             String url = target.getString("url");
@@ -126,8 +126,8 @@ public class ServiceConfig {
             String user=target.getString("user",null);
             String password=target.getString("password",null);
             String filterStr = target.getString("filter","direct");
-            Boolean dayOnly = target.getBoolean("day_only",Boolean.FALSE);
-            String startDay = target.getString("start_day",null);            
+            Boolean dayOnly = target.getBoolean("dayOnly",Boolean.FALSE);
+            String startDay = target.getString("startDay",null);            
             String dateStampFormat = target.getString("dateStampFormat");           
             if (dayOnly) { //startDay must be defined for dayOnly strategy                        	      
                 boolean validStartDay=HarvestTimeUtil.validateDayFormat(startDay);

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -126,11 +126,11 @@ public class ServiceConfig {
             String password=target.getString("password",null);
             String filterStr = target.getString("filter","direct");
             Boolean dayOnly = target.getBoolean("day_only",Boolean.FALSE);
-        	String startDay = target.getString("start_day",null);            
-            if (dayOnly) { //startDay must be defined for datOnly strategy                        	      
-            	boolean validStartDay=HarvestTimeUtil.validateDayFormat(startDay);
+            String startDay = target.getString("start_day",null);            
+            if (dayOnly) { //startDay must be defined for dayOnly strategy                        	      
+                boolean validStartDay=HarvestTimeUtil.validateDayFormat(startDay);
                 if (!validStartDay) {
-                 	throw new IllegalArgumentException("Failed to parse startDate for OAI target with dayOnly strategy. Day="+startDay);
+                    throw new IllegalArgumentException("Failed to parse 'start_day' for OAI target with 'day_only' strategy. start_day="+startDay +" OAI target="+name);
                 }            	
             }
             

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dk.kb.datahandler.model.v1.OaiTargetDto;
+import dk.kb.datahandler.model.v1.OaiTargetDto.DateStampFormatEnum;
 import dk.kb.datahandler.util.HarvestTimeUtil;
 import dk.kb.util.yaml.YAML;
 
@@ -127,6 +128,7 @@ public class ServiceConfig {
             String filterStr = target.getString("filter","direct");
             Boolean dayOnly = target.getBoolean("day_only",Boolean.FALSE);
             String startDay = target.getString("start_day",null);            
+            String dateStampFormat = target.getString("dateStampFormat");           
             if (dayOnly) { //startDay must be defined for dayOnly strategy                        	      
                 boolean validStartDay=HarvestTimeUtil.validateDayFormat(startDay);
                 if (!validStartDay) {
@@ -155,6 +157,13 @@ public class ServiceConfig {
             oaiTarget.setFilter(filter);
             oaiTarget.setDayOnly(dayOnly);
             oaiTarget.setStartDay(startDay);
+            try {
+              oaiTarget.setDateStampFormat(DateStampFormatEnum.fromValue(dateStampFormat));
+            }
+            catch(Exception e) {
+                log.warn("dateStampFormat not 'day' or 'date':"+dateStampFormat);
+            }
+                    
             oaiTargets.put(name, oaiTarget);
             
             log.info("Load OAI target from yaml:"+name);

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -237,7 +237,7 @@ public class DsDatahandlerFacade {
        		return delta;    		
        	}
        	else {
-       		Integer delta = oaiIngestFull(oaiTargetName);	
+       		Integer delta = oaiIngestFullImpl(oaiTargetName);	
        		return delta;
        	}    	
     	

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -3,6 +3,7 @@ package dk.kb.datahandler.facade;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Target;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -187,7 +188,7 @@ public class DsDatahandlerFacade {
      protected static Integer oaiIngestJobScheduler(String oaiTargetName,ArrayList<OaiFromUntilInterval> fromUntilList) throws Exception {                
          int totalNumber=0;
                   
-         log.info("Starting jobs from number of FromUntilIntervals:"+fromUntilList.size());
+         log.info("Starting jobs from number of FromUntilIntervals:"+fromUntilList.size() +" for target:"+oaiTargetName);
          for (OaiFromUntilInterval fromUntil: fromUntilList) {         
              //Test no job is running before starting new for same target
              validateNotAlreadyRunning(oaiTargetName);  //If we want to multithread preservica harvest, this has to be removed      
@@ -259,21 +260,6 @@ public class DsDatahandlerFacade {
         //Dirty but quick solution fix. Best would be if COP could fix it
 
         OaiTargetDto oaiTargetDto = job.getDto();
-
-        // A little custom tweaking because none of our the OAI servers seems to follow full spec for datestamp format
-        if (from != null && oaiTargetDto.getUrl().indexOf("kb.dk/cop/")> 0) {
-            from = from.substring(0,10);               
-        }
-        else { //For preservica. Enforce UTC but still allowing yyyy-MM-dd as input and fix behind the scenes.
-            
-            if (from != null && from.length() ==10) {
-                from=from+"T00:00:00Z";
-            }
-            if (until != null && until.length() ==10) {
-                until=until+"T00:00:00Z";
-            }            
-        }
-        
 
         // TODO: Change this to datasource in the OpenAPI specification
         String origin=oaiTargetDto.getDatasource();

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -1,24 +1,5 @@
 package dk.kb.datahandler.facade;
 
-import dk.kb.datahandler.config.ServiceConfig;
-import dk.kb.datahandler.model.v1.OaiJobDto;
-import dk.kb.datahandler.model.v1.OaiTargetDto;
-import dk.kb.datahandler.oai.*;
-import dk.kb.datahandler.util.HarvestTimeUtil;
-import dk.kb.datahandler.util.SolrUtils;
-import dk.kb.storage.client.v1.DsStorageApi;
-import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.OriginCountDto;
-import dk.kb.storage.util.DsStorageClient;
-import dk.kb.util.webservice.exception.InternalServiceException;
-import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
-import org.apache.commons.io.IOUtils;
-import org.apache.solr.client.solrj.SolrServerException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +9,32 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import dk.kb.datahandler.config.ServiceConfig;
+import dk.kb.datahandler.model.v1.OaiJobDto;
+import dk.kb.datahandler.model.v1.OaiTargetDto;
+import dk.kb.datahandler.oai.OaiHarvestClient;
+import dk.kb.datahandler.oai.OaiJobCache;
+import dk.kb.datahandler.oai.OaiRecord;
+import dk.kb.datahandler.oai.OaiResponse;
+import dk.kb.datahandler.oai.OaiResponseFilter;
+import dk.kb.datahandler.oai.OaiResponseFilterPreservica;
+import dk.kb.datahandler.oai.OaiTargetJob;
+import dk.kb.datahandler.util.HarvestTimeUtil;
+import dk.kb.datahandler.util.SolrUtils;
+import dk.kb.storage.client.v1.DsStorageApi;
+import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.OriginCountDto;
+import dk.kb.storage.util.DsStorageClient;
+import dk.kb.util.webservice.exception.InternalServiceException;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 
 public class DsDatahandlerFacade {

--- a/src/main/java/dk/kb/datahandler/oai/OaiFromUntilInterval.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiFromUntilInterval.java
@@ -1,0 +1,93 @@
+package dk.kb.datahandler.oai;
+
+import dk.kb.datahandler.util.HarvestTimeUtil;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
+
+/**
+ * Date interval wrapper class used as dates 'from' and 'until' when harvesting OAi targets 
+ * 
+ */
+public class OaiFromUntilInterval {
+    
+    private String from;
+    private String until;
+
+
+    /**
+     * Interval for harvesting a OAI target. <br>
+     * Some OAI servers do not all support UTC format. (KB-COP only accepts day format etc.)
+     * From and until must have same granularity. Datestamp formats must be one of the following formats:<br
+     * yyyy-MM-dd or yyyy-MM-ddT0mm:hh:ssZ <br>
+     * Examples:  2022-07-12T00:00:00Z or 2022-07-12
+     * 
+     * @param from Datestamp for start of the harvest. Must not be null
+     * @param until If null, it will harvest everything until today
+     * 
+     */
+    public OaiFromUntilInterval(String from, String until) throws InvalidArgumentServiceException{  
+        validateFormat(from, until);    
+    
+        this.from=from;
+        this.until=until;    
+    }
+
+
+    public String getFrom() {
+        return from;
+    }
+
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+
+    public String getUntil() {
+        return until;
+    }
+
+    private void validateFormat(String from, String until) throws InvalidArgumentServiceException{
+        if (from == null ) {        
+            throw new InvalidArgumentServiceException("From date can not be null");
+        }
+        if (until != null && (from.length() != until.length()) ) {
+            throw new InvalidArgumentServiceException("From and until are in different dateformats. from="+from  +"until="+until);
+
+        }
+        //Validate format is one of the two accepted formats.
+        if (from.length() == 10) { //Until will have same length
+            if (!HarvestTimeUtil.validateDayFormat(from)) {
+                throw new InvalidArgumentServiceException("Invalid date format. from="+from);
+            }
+            if (until != null) {
+                if (!HarvestTimeUtil.validateDayFormat(until)) {
+                    throw new InvalidArgumentServiceException("Invalid date format. until="+from);
+                }          
+            }
+
+        }
+        else if(from.length() ==20 ) {
+            if (!HarvestTimeUtil.validateOaiDateFormat(from)) {
+                throw new InvalidArgumentServiceException("Invalid date format. from="+from);
+            }
+            if (until != null) {
+                if (!HarvestTimeUtil.validateOaiDateFormat(until)) {
+                    throw new InvalidArgumentServiceException("Invalid date format. until="+from);
+                }          
+            }         
+        }
+        else {
+            throw new InvalidArgumentServiceException("Date format is not yyyy-MM-dd or yyyy-MM-ddT0mm:hh:ssZ . from="+from);
+        }
+    }
+
+
+    @Override
+    public String toString() {
+        return "OaiFromUntilInterval [from=" + from + ", until=" + until + "]";
+    }
+
+    
+    
+}
+

--- a/src/main/java/dk/kb/datahandler/oai/OaiJobCache.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiJobCache.java
@@ -51,8 +51,8 @@ public class OaiJobCache {
         job.setCompletedTime(System.currentTimeMillis());        
         log.info("Setting completed for job:"+job.getDto().getName() +" time:"+job.getCompletedTime());
     
-        //We do not want more than 1000 completed jobs 
-        if (completedJobsMap.size() > 1000) {
+        //We do not want more than 10000 completed jobs 
+        if (completedJobsMap.size() > 10000) { //because preservica harvest 1 day at a time. it is increased to 10K 
             completedJobsMap.remove(completedJobsMap.firstKey()); //Remove oldest
         }
         

--- a/src/main/java/dk/kb/datahandler/oai/OaiResponseFilterPreservica.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiResponseFilterPreservica.java
@@ -155,8 +155,8 @@ public class OaiResponseFilterPreservica extends OaiResponseFilter {
             return RecordTypeDto.MANIFESTATION;
         }
 
-        log.debug("Unable to derive record type for id '{}' from datasource '{}'. Falling back to '{}'",
-                storageId, datasource, RecordTypeDto.DELIVERABLEUNIT);
+        //TODO Until "so"-records are XSLT handled correct, this line will spam too much even on debug. Instead maybe give a count of discarded after each batch  
+        //log.debug("Unable to derive record type for id '{}' from datasource '{}'. Falling back to '{}'", storageId, datasource, RecordTypeDto.DELIVERABLEUNIT);
         return RecordTypeDto.DELIVERABLEUNIT;
     }
 }

--- a/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
@@ -10,6 +10,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -18,6 +21,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 import org.slf4j.Logger;
@@ -36,21 +40,21 @@ import dk.kb.datahandler.oai.OaiFromUntilInterval;
  */
 
 public class HarvestTimeUtil {
-    
+
     public static final String DEFAULT_START_DATE="1900-01-01T00:00:00Z"; //Used as start if no file has been written yet for that target
     private static final Logger log = LoggerFactory.getLogger(HarvestTimeUtil.class);
     private static final Charset UTF8= StandardCharsets.UTF_8;         
     private static final String DAY_PATTERN = "yyyy-MM-dd";
-    
-    
+
+
     public static synchronized String loadLastHarvestTime(OaiTargetDto oaiTarget) throws Exception{            
         String oaiTargetNameFile = getFileNameFromOaiTarget(oaiTarget);        
         return loadLastHarvestTime(oaiTargetNameFile);        
     }
-    
-    
+
+
     public static synchronized void updateDatestampForOaiTarget(OaiTargetDto oaiTarget, String datestamp) throws Exception{        
-        
+
         //Hack to fix datestamp returned from Preservica. Format returned are not in OAI standard and is parsed wrong (downgrade to seconds) when given to preservica.
         //Only preservica 6 does not, preservica 5 gives correct format.
         if (datestamp.length() >20) { // 2021-03-24T19:57:34.123Z -> 2021-03-24T19:57:34Z 
@@ -59,17 +63,17 @@ public class HarvestTimeUtil {
         else if(datestamp.length()==10) {             
             datestamp=datestamp+"T00:00:00Z";
         }
-        
+
         if (!validateOaiDateFormat(datestamp)) {
             log.error("Datestamp not valid format:"+datestamp +" for Oai target:"+oaiTarget.getName());
             throw new InvalidArgumentServiceException("Datastamp not valid format:" + datestamp);
         }
-        
-        
+
+
         String oaiTargetNameFile = getFileNameFromOaiTarget(oaiTarget);
         updateDatestampForOaiTarget(oaiTargetNameFile, datestamp);        
     }
-    
+
     /**
      * Validate day format is of form at yyyy-MM-dd.
      * Example: 2024-02-09
@@ -77,19 +81,19 @@ public class HarvestTimeUtil {
      * @param day  Validate is of correct format
      */
     public static boolean validateDayFormat(String day) {
-    	SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);
         simpleDateFormat.setLenient(false); //day must exist
-    try {    	
-    	   Date date = simpleDateFormat.parse(day);    	   
-    	}
-    	catch(Exception e) {
-    		log.warn("Parsing of day format failed:"+day);
-    	    return false;
-    	}
+        try {    	
+            Date date = simpleDateFormat.parse(day);    	   
+        }
+        catch(Exception e) {
+            log.warn("Parsing of day format failed:"+day);
+            return false;
+        }
         return true;			
-    	    	
+
     }
-    
+
     /**
      * 
      * From a java date format yyyy-MM-dd
@@ -97,42 +101,52 @@ public class HarvestTimeUtil {
      * @param date  Java date object
      */
     public static String formatDate2Day(Date date) {
-    	SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);    	    	    	
-    	String day = simpleDateFormat.format(date);    	       	    
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);    	    	    	
+        String day = simpleDateFormat.format(date);    	       	    
         return day;			    	    
     }
-    
-    
+
+
     /**
      * Some OAI targets needs to be split into days instead of a full date interval. 
      * Will format from and until date to a format supported by the OAI target<br> 
+     * 
+     * @param oaiTarget The OAI target to generate intervals for. The interval timeformat will match what the oai target has defined. 
+     * @param from  Generate day intervals starting from this day (included). If null it will start from the start_day attribute defined for the oai target.
+     * 
      */
-    public static ArrayList<OaiFromUntilInterval> generateFromUntilIntervalForFullIngest( OaiTargetDto oaiTarget) throws Exception{
-        
+    public static ArrayList<OaiFromUntilInterval> generateFromUntilInterval( OaiTargetDto oaiTarget , String from) throws Exception{
+
         ArrayList<OaiFromUntilInterval> intervals = new ArrayList<OaiFromUntilInterval>();
-        String from= null;        
-        //From date
-        if (oaiTarget.getDayOnly()) {
-            from=oaiTarget.getStartDay(); //Since we harvest by day, we need a start day and not from year 1900
-            from+="T00:00:00Z";
-        }
-        else {
-            from=HarvestTimeUtil.DEFAULT_START_DATE; //year 1900. 
+        if(from != null) {
+            if (!HarvestTimeUtil.validateOaiDateFormat(from)) {
+                log.warn("From datestamp not in UTC format:"+from); //Should not happen as this is called internally only
+                throw new InvalidArgumentServiceException("From datestamp not in UTC format:"+from);
+            }
         }        
-        
+        else { //From is null and set default        
+            //From date
+            if (oaiTarget.getDayOnly()) {
+                from=oaiTarget.getStartDay(); //Since we harvest by day, we need a start day and not from year 1900
+                from+="T00:00:00Z"; 
+            }
+            else {
+                from=HarvestTimeUtil.DEFAULT_START_DATE; //year 1900. 
+            }        
+        }
+
         //Full interval or daily
         if (oaiTarget.getDayOnly()) {
             String dayStamp = from.substring(0,10); //day only
             String nextDay=HarvestTimeUtil.getNextDayIfNot2DaysInFuture(dayStamp);
             //Build all day intervals until tomorrow
-            while (nextDay!= null) {
-           System.out.println("next day:"+nextDay);
-               String fromFormattet= formatDateForOaiTarget(dayStamp, oaiTarget);
-               String untilFormattet = formatDateForOaiTarget(nextDay, oaiTarget);               
-               intervals.add(new OaiFromUntilInterval(fromFormattet, untilFormattet)); // Add the day
-             
-               dayStamp=nextDay;
-               nextDay=HarvestTimeUtil.getNextDayIfNot2DaysInFuture(nextDay); //when null it will stop           
+            while (nextDay!= null) {       
+                String fromFormattet= formatDateForOaiTarget(dayStamp, oaiTarget);
+                String untilFormattet = formatDateForOaiTarget(nextDay, oaiTarget);               
+                intervals.add(new OaiFromUntilInterval(fromFormattet, untilFormattet)); // Add the day
+
+                dayStamp=nextDay;
+                nextDay=HarvestTimeUtil.getNextDayIfNot2DaysInFuture(nextDay); //when null it will stop           
             }            
         }
         else {
@@ -140,10 +154,10 @@ public class HarvestTimeUtil {
             intervals.add(new OaiFromUntilInterval(fromFormatted, null)); // no until
         }                
         return intervals;
-        
+
     }
-    
-    
+
+
     /**
      * Return the next day. Return null if next day will be after tomorrow.  <br>
      * So if today is 2024-02-07, the last day that will be return is 2024-02-08. Else it will be null.
@@ -154,34 +168,34 @@ public class HarvestTimeUtil {
      * @param day day in format yyyy-MM.dd
      */
     public static String getNextDayIfNot2DaysInFuture(String day) throws InvalidArgumentServiceException {
-    	SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);
-    	Date date = null;
-    	try{
-    		 date = simpleDateFormat.parse(day);
-    	}
-    	catch(Exception e) {
-    		throw new InvalidArgumentServiceException("Not valid day:"+day);
-    	}
-    	
-    	//Add one day
-    	Calendar nextDayCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"),Locale.ROOT);
-    	nextDayCal.setTime(date ); //Set time from input
-    	nextDayCal.add(Calendar.DATE, 1);
-    	
-    	Calendar future1DaysCal=Calendar.getInstance(TimeZone.getTimeZone("UTC"),Locale.ROOT);
-        future1DaysCal.add(Calendar.DATE, 1); 
-    	
-        //more than 1 day in future. 1 day + 1 millis is enough 
-        if (nextDayCal.getTimeInMillis() > future1DaysCal.getTimeInMillis()){        
-        	return null;
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);
+        Date date = null;
+        try{
+            date = simpleDateFormat.parse(day);    		
         }
-        
-    	//return date format in yyyy-MM-dd
-    	String nextDay=  simpleDateFormat.format(nextDayCal.getTime());
-    	System.out.println(day +">"+nextDay);
+        catch(Exception e) {
+            throw new InvalidArgumentServiceException("Not valid day:"+day);
+        }
+
+        LocalDate nextDayLocal = LocalDate.parse(day).plusDays(1);
+        String nextDay=nextDayLocal.toString();        
+
+        if (nextDay.equals(day)) {//Sanity check. 
+            throw new InternalServiceException("Could not calculate next day for:"+nextDay);            
+        }
+
+        //Check if the following day is 2 days in future.
+        LocalDate nextNextDayLocal = LocalDate.parse(day);
+        long nextNextDayMillis=nextNextDayLocal.toEpochSecond(LocalTime.parse("00:00:01"), ZoneOffset.UTC);
+
+        //more than 1 day in future. 1 day + 1sec enough 
+        if (nextNextDayMillis >= System.currentTimeMillis()/1000){  //Seconds so have to divide by 1000              	
+            return null;
+        }
+
         return nextDay;    	    	
     }
-    
+
     protected static String loadLastHarvestTime(String oaiTargetNameFile ) throws Exception{                        
         Path oaiTargetFilePath = Paths.get( oaiTargetNameFile);
         if (!Files.exists(oaiTargetFilePath)) {            
@@ -195,12 +209,12 @@ public class HarvestTimeUtil {
                 log.error(errorMsg);
                 throw new InvalidArgumentServiceException(errorMsg);
             }
-            
+
             log.info("OAI target: "+oaiTargetNameFile +" has last harvestDate:"+lastHarvestDate);
             return lastHarvestDate;
         }               
     }
-    
+
     protected static void updateDatestampForOaiTarget(String oaiTargetNameFile, String datestamp) throws Exception{        
         deleteFileAndWriteToFile(oaiTargetNameFile, datestamp);
         log.info("Update last harvest datestamp for oai target:"+oaiTargetNameFile+" with:"+datestamp);
@@ -209,16 +223,16 @@ public class HarvestTimeUtil {
     protected static String getFileNameFromOaiTarget(OaiTargetDto oaiTarget) {        
         return ServiceConfig.getOaiTimestampFolder() +"/"+oaiTarget.getName()+".txt";        
     }
-        
-    
+
+
     protected static String getFirstLineFromFile(String fileName) throws IOException {
         BufferedReader br = new BufferedReader(new FileReader(fileName, UTF8)); 
         String line = br.readLine(); 
         br.close();
         return line;
     }
-    
-    
+
+
     protected static void deleteFileAndWriteToFile(String fileName, String lastHarvestDate) throws IOException {        
         Files.deleteIfExists(Paths.get(fileName));                
         FileOutputStream outputStream = new FileOutputStream(fileName);
@@ -226,14 +240,14 @@ public class HarvestTimeUtil {
         outputStream.write(strToBytes);
         outputStream.close();                        
     }
-    
+
     /**
      * 
      * Validate UTC timestamp, format is strict and only seconds allowed
      * 
      * example: 2021-03-24T19:57:34Z
      */
-     
+
     public static boolean validateOaiDateFormat(String datestamp) {            
 
         try {
@@ -242,7 +256,7 @@ public class HarvestTimeUtil {
         } catch (DateTimeParseException e) {
             return false;
         }
-     }
+    }
 
     /**
      * Some OAI servers only support day yyyy-MM-dd format and UTC format will be reduced to day 
@@ -262,7 +276,7 @@ public class HarvestTimeUtil {
             return date.substring(0,10); //reduce
         }                
     }
-   
-    
+
+
 
 }

--- a/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
@@ -94,18 +94,6 @@ public class HarvestTimeUtil {
 
     }
 
-    /**
-     * 
-     * From a java date format yyyy-MM-dd
-     * 
-     * @param date  Java date object
-     */
-    public static String formatDate2Day(Date date) {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);    	    	    	
-        String day = simpleDateFormat.format(date);    	       	    
-        return day;			    	    
-    }
-
 
     /**
      * Some OAI targets needs to be split into days instead of a full date interval. 
@@ -164,6 +152,7 @@ public class HarvestTimeUtil {
      * 
      * 
      * For input 2024-02-07 the output will be 2024-02-08  
+     * If today is 2024-02-19. Input of 2024-02-19 will give 2024-02-20. But 2024-02-20 will give null.  
      * 
      * @param day day in format yyyy-MM.dd
      */
@@ -177,7 +166,7 @@ public class HarvestTimeUtil {
             throw new InvalidArgumentServiceException("Not valid day:"+day);
         }
 
-        LocalDate nextDayLocal = LocalDate.parse(day).plusDays(1);
+        LocalDate nextDayLocal = LocalDate.parse(day).plusDays(1); //add 1 day to input day        
         String nextDay=nextDayLocal.toString();        
 
         if (nextDay.equals(day)) {//Sanity check. 
@@ -185,14 +174,14 @@ public class HarvestTimeUtil {
         }
 
         //Check if the following day is 2 days in future.
-        LocalDate nextNextDayLocal = LocalDate.parse(day);
-        long nextNextDayMillis=nextNextDayLocal.toEpochSecond(LocalTime.parse("00:00:01"), ZoneOffset.UTC);
-
-        //more than 1 day in future. 1 day + 1sec enough 
-        if (nextNextDayMillis >= System.currentTimeMillis()/1000){  //Seconds so have to divide by 1000              	
+        LocalDate twoDaysFromToday=LocalDate.now().plusDays(2);//Must not return value if we over this date
+        
+        //Count days since 1970. ( 2024-01-01 is about 19700 days etc.)
+        long daysNext=nextDayLocal.toEpochDay();
+        long daysTwoDaysFromToday=twoDaysFromToday.toEpochDay();
+        if (daysNext >= daysTwoDaysFromToday) {
             return null;
-        }
-
+        }                
         return nextDay;    	    	
     }
 
@@ -266,7 +255,7 @@ public class HarvestTimeUtil {
      * @return date in UTC format or date in day format
      */
     private static String formatDateForOaiTarget(String date, OaiTargetDto oaiTarget) {
-        if (oaiTarget.getDateStampFormat().equals(DateStampFormatEnum.DATE)) {
+        if (oaiTarget.getDateStampFormat().equals(DateStampFormatEnum.DATETIME)) {
             if(date.length()==10) {
                 date=date+"T00:00:00Z";// expand if not already date
             }
@@ -277,6 +266,6 @@ public class HarvestTimeUtil {
         }                
     }
 
-
+    
 
 }

--- a/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
@@ -109,11 +110,11 @@ public class HarvestTimeUtil {
     	}
     	
     	//Add one day
-    	Calendar nextDayCal = Calendar.getInstance();
+    	Calendar nextDayCal = Calendar.getInstance(TimeZone.getDefault(),Locale.getDefault());
     	nextDayCal.setTime(date ); //Set time from input
     	nextDayCal.add(Calendar.DATE, 1);
     	
-    	Calendar future1DaysCal=Calendar.getInstance();
+    	Calendar future1DaysCal=Calendar.getInstance(TimeZone.getDefault(),Locale.getDefault());
         future1DaysCal.add(Calendar.DATE, 1); 
     	
         //more than 1 day in future. 1 day + 1 millis is enough 

--- a/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
@@ -47,7 +47,7 @@ public class HarvestTimeUtil {
     
     public static synchronized void updateDatestampForOaiTarget(OaiTargetDto oaiTarget, String datestamp) throws Exception{        
         
-        //Hack to fix datestamp for Preservica.
+        //Hack to fix datestamp return from Preservica. Format returned are not in OAI standard and is parsed wrong (downgrade to day) when given to preservica.
         if (datestamp.length() >20) { // 2021-03-24T19:57:34.123Z -> 2021-03-24T19:57:34Z 
             datestamp=datestamp.substring(0,19)+"Z";
         }

--- a/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
@@ -48,8 +48,8 @@ public class HarvestTimeUtil {
     public static synchronized void updateDatestampForOaiTarget(OaiTargetDto oaiTarget, String datestamp) throws Exception{        
         
         //Hack to fix datestamp for Preservica.
-        if (datestamp.length() >20) { // 2021-03-24T19:57:34.123Z -> 2021-03-24T19:57:34Z. 
-            datestamp=datestamp.substring(0,20)+"Z";
+        if (datestamp.length() >20) { // 2021-03-24T19:57:34.123Z -> 2021-03-24T19:57:34Z 
+            datestamp=datestamp.substring(0,19)+"Z";
         }
             
         if (!validateOaiDateFormat(datestamp)) {

--- a/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
+++ b/src/main/java/dk/kb/datahandler/util/HarvestTimeUtil.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
@@ -173,8 +174,8 @@ public class HarvestTimeUtil {
             throw new InternalServiceException("Could not calculate next day for:"+nextDay);            
         }
 
-        //Check if the following day is 2 days in future.
-        LocalDate twoDaysFromToday=LocalDate.now().plusDays(2);//Must not return value if we over this date
+        //Check if the following day is 2 days in future. 
+        LocalDate twoDaysFromToday=LocalDate.now(Clock.systemUTC()).plusDays(2);//Must not return value if we over this date
         
         //Count days since 1970. ( 2024-01-01 is about 19700 days etc.)
         long daysNext=nextDayLocal.toEpochDay();

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -327,14 +327,14 @@ components:
             * `datetime`:    Use UTC format yyyy-MM-ddThh:mm:ssZ as from/until parameters. This is default.                        
           example: 'date'
           default: 'date'
-        day_only:
+        dayOnly:
           type: boolean          
           description: 'OAI harvest will fetch by day using from until. This is required for OAI servers that does not scale'                        
           example: true
           default: false        
-        start_day: 
+        startDay: 
           type: string
-          description: 'Date of format yyyy-MM-dd. Only used if day_only attribute is true'                        
+          description: 'Date of format yyyy-MM-dd. Only used if dayOnly attribute is true'                        
           example: '2020-01-01'
          
           

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -73,7 +73,6 @@ paths:
           description: 'Name of the oai target to start full import. '
           required: true
           schema:
-            enum: [${oai_targets}]
             type: string
       responses:
         '200':
@@ -95,8 +94,7 @@ paths:
           in: query
           description: 'Name of the oai target to start delta import'
           required: true
-          schema:
-            enum: [${oai_targets}]
+          schema:            
             type: string
       responses:
         '200':

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -318,11 +318,20 @@ components:
                             [Preservica](https://preservica.com/) XIP content of the record
           example: 'direct'
           default: 'direct'
+        dateStampFormat:
+          type: string
+          enum:  ['day', 'date']
+          description: |
+            Special handling of record. Possible value are
+            * `day`:     Only use format yyyy-MM-dd as from/until parameters
+            * `date`:    Use UTC format yyyy-MM-ddThh:mm:ssZ as from/until parameters. This is default.                        
+          example: 'date'
+          default: 'date'
         day_only:
           type: boolean          
           description: 'OAI harvest will fetch by day using from until. This is required for OAI servers that does not scale'                        
           example: true
-          default: false
+          default: false        
         start_day: 
           type: string
           description: 'Date of format yyyy-MM-dd. Only used if day_only attribute is true'                        

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -320,11 +320,11 @@ components:
           default: 'direct'
         dateStampFormat:
           type: string
-          enum:  ['day', 'date']
+          enum:  ['date', 'datetime']
           description: |
             Special handling of record. Possible value are
-            * `day`:     Only use format yyyy-MM-dd as from/until parameters
-            * `date`:    Use UTC format yyyy-MM-ddThh:mm:ssZ as from/until parameters. This is default.                        
+            * `date`:     Only use format yyyy-MM-dd as from/until parameters
+            * `datetime`:    Use UTC format yyyy-MM-ddThh:mm:ssZ as from/until parameters. This is default.                        
           example: 'date'
           default: 'date'
         day_only:

--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -320,6 +320,17 @@ components:
                             [Preservica](https://preservica.com/) XIP content of the record
           example: 'direct'
           default: 'direct'
+        day_only:
+          type: boolean          
+          description: 'OAI harvest will fetch by day using from until. This is required for OAI servers that does not scale'                        
+          example: true
+          default: false
+        start_day: 
+          type: string
+          description: 'Date of format yyyy-MM-dd. Only used if day_only attribute is true'                        
+          example: '2020-01-01'
+         
+          
 
     OaiJob:
       type: object

--- a/src/test/java/dk/kb/datahandler/oai/OaiHarvestClientIntegrationTest.java
+++ b/src/test/java/dk/kb/datahandler/oai/OaiHarvestClientIntegrationTest.java
@@ -45,7 +45,7 @@ public class OaiHarvestClientIntegrationTest {
 //       String set="oai:kb.dk:images:billed:2014:jun:hca";
        OaiTargetJob job = DsDatahandlerFacade.createNewJob(oaiTarget);        
        
-       OaiHarvestClient client = new OaiHarvestClient(job,from);
+       OaiHarvestClient client = new OaiHarvestClient(job,from,null);
        
        OaiResponse r1 = client.next();
        System.out.println("records:"+r1.getRecords().size());

--- a/src/test/java/dk/kb/datahandler/pvica/PvicaDataTest.java
+++ b/src/test/java/dk/kb/datahandler/pvica/PvicaDataTest.java
@@ -173,7 +173,7 @@ public class PvicaDataTest {
         //Empty test OAI Target
         OaiTargetDto dto = new OaiTargetDto();
         OaiTargetJob job = new OaiTargetJob(1, dto);
-        OaiHarvestClient client = new OaiHarvestClient(job, "test");
+        OaiHarvestClient client = new OaiHarvestClient(job, "test",null);
         OaiRecord oaiRecord = client.extractRecordsFromXml(doc).get(0);
         String testStorageId = "ds.test:" + oaiRecord.getId();
 

--- a/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
@@ -10,8 +10,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -22,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import dk.kb.datahandler.model.v1.OaiTargetDto;
 import dk.kb.datahandler.model.v1.OaiTargetDto.DateStampFormatEnum;
 import dk.kb.datahandler.oai.OaiFromUntilInterval;
-import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 public class HarvestTimeUtilTest {
 
@@ -79,11 +82,8 @@ public class HarvestTimeUtilTest {
     	    	
     	assertEquals("2020-01-02",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-01-01")); //1 day
     	assertEquals("2021-01-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-12-31")); //new year        
-        assertEquals("2022-02-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2022-01-31")); //new year 
-      //assertEquals("2022-11-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2022-10-30")); //new year
-
-        
-//      assertEquals("1942-11-03",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("1942-11-02")); //new year
+        assertEquals("2022-02-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2022-01-31")); //new month      
+        assertEquals("2022-10-31",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2022-10-30")); //troublesome day with summer/winter time        
         
         
         
@@ -104,9 +104,14 @@ public class HarvestTimeUtilTest {
     @Test
     void testGenerateDayIntervals() throws Exception {    
         OaiTargetDto target = getDayOnlyTarget();
-        ArrayList<OaiFromUntilInterval> intervals= HarvestTimeUtil.generateFromUntilIntervalForFullIngest(target);
-        System.out.println(intervals);
+        ArrayList<OaiFromUntilInterval> intervals= HarvestTimeUtil.generateFromUntilInterval(target,null);                
+        OaiFromUntilInterval last = intervals.get(intervals.size()-1);        
+        //'from' attribute in last interval must be today
+        String mustBeToday = last.getFrom().substring(0,10);//Get day part
+        String today=HarvestTimeUtil.formatDate2Day(new Date());
+        assertEquals(today,mustBeToday);        
     }
+    
     
     
     @Test
@@ -152,16 +157,14 @@ public class HarvestTimeUtilTest {
     }
     
     
-    private OaiTargetDto getDayOnlyTarget()  {
-        
+    private OaiTargetDto getDayOnlyTarget()  {        
         OaiTargetDto target= new OaiTargetDto();
         target.setDayOnly(true);
         target.setName("test day only target");
-        target.setDateStampFormat(DateStampFormatEnum.DATE);
-        target.setStartDay("2022-01-15");
-        return target;
-        
-        
+        target.setDateStampFormat(DateStampFormatEnum.DATE);        
+        int year =  LocalDate.now(ZoneId.of("Z")).getYear();        
+        target.setStartDay(year+"-01-01"); //Jan 1 this year
+        return target;                
         
     }
     

--- a/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -74,7 +76,8 @@ public class HarvestTimeUtilTest {
     
         //Test 2 days in future
     	//Construct today in format yyyy-MM-dd
-    	String today = HarvestTimeUtil.formatDate2Day(Calendar.getInstance().getTime());
+    	Calendar cal = Calendar.getInstance(TimeZone.getDefault(),Locale.getDefault());
+    	String today = HarvestTimeUtil.formatDate2Day(cal.getTime());
     	
     	//Next day must be returned
     	String tomorrow=HarvestTimeUtil.getNextDayIfNot2DaysInFuture(today);    	

--- a/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -17,6 +18,11 @@ import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import dk.kb.datahandler.model.v1.OaiTargetDto;
+import dk.kb.datahandler.model.v1.OaiTargetDto.DateStampFormatEnum;
+import dk.kb.datahandler.oai.OaiFromUntilInterval;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 public class HarvestTimeUtilTest {
 
@@ -40,7 +46,7 @@ public class HarvestTimeUtilTest {
         
         // Test file does not exist
         String last = HarvestTimeUtil.loadLastHarvestTime( persistenceFile);        
-        assertEquals(HarvestTimeUtil.defaultStartDate,last);
+        assertEquals(HarvestTimeUtil.DEFAULT_START_DATE,last);
         
         //Test create new file
         HarvestTimeUtil.deleteFileAndWriteToFile(persistenceFile, "2020-01-02T12:34:59Z");
@@ -72,8 +78,15 @@ public class HarvestTimeUtilTest {
     void testGetNextDay() throws Exception {    	
     	    	
     	assertEquals("2020-01-02",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-01-01")); //1 day
-    	assertEquals("2021-01-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-12-31")); //new year
-    
+    	assertEquals("2021-01-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-12-31")); //new year        
+        assertEquals("2022-02-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2022-01-31")); //new year 
+      //assertEquals("2022-11-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2022-10-30")); //new year
+
+        
+//      assertEquals("1942-11-03",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("1942-11-02")); //new year
+        
+        
+        
         //Test 2 days in future
     	//Construct today in format yyyy-MM-dd
     	Calendar cal = Calendar.getInstance(TimeZone.getDefault(),Locale.getDefault());
@@ -88,10 +101,16 @@ public class HarvestTimeUtilTest {
     	assertNull(todayPlus2Days); //2 days in future     	    
     }
 	
+    @Test
+    void testGenerateDayIntervals() throws Exception {    
+        OaiTargetDto target = getDayOnlyTarget();
+        ArrayList<OaiFromUntilInterval> intervals= HarvestTimeUtil.generateFromUntilIntervalForFullIngest(target);
+        System.out.println(intervals);
+    }
+    
     
     @Test
-    void testUtcSecondsFormat() {
-                   
+    void testUtcSecondsFormat() {                  
         //All valid
         assertTrue(HarvestTimeUtil.validateOaiDateFormat("2020-01-01T00:00:00Z"));
         assertTrue(HarvestTimeUtil.validateOaiDateFormat("2021-03-24T19:57:34Z"));
@@ -102,5 +121,49 @@ public class HarvestTimeUtilTest {
         assertFalse(HarvestTimeUtil.validateOaiDateFormat("2021-03-24T19:57:34.00.00Z"));
         assertFalse(HarvestTimeUtil.validateOaiDateFormat("2021-03-24T19:57:34.00.000Z"));         
     }
+    
+    @Test
+    void testOaiFromUntilInterval() {
+       //Date formats must have same format and be yyyy-DD-mm or yyyy-MM-ddTmm:hh:ssZ. Until can be null  
+        
+       //All valid
+       assertTrue(oaiFromUntilIntervalValid("2020-01-01T00:00:00Z", "2020-02-01T00:00:00Z"));                                      
+       assertTrue(oaiFromUntilIntervalValid("2020-01-01T00:00:00Z", null));  
+       assertTrue(oaiFromUntilIntervalValid("2020-01-01", "2020-02-01"));                        
+       assertTrue(oaiFromUntilIntervalValid("2020-01-01", null));                    
+                       
+        //None valid
+       assertFalse(oaiFromUntilIntervalValid("2020-01-01T00:00:00.00Z", null)); //millis not allowed
+       assertFalse(oaiFromUntilIntervalValid("2020-01-01T", null));
+       assertFalse(oaiFromUntilIntervalValid(null,"2020-01-01T00:00:00Z"));
+       assertFalse(oaiFromUntilIntervalValid("2020-01-01","2020-01-01T00:00:00Z"));//Mixing formats
+       assertFalse(oaiFromUntilIntervalValid(null,null));
+        
+    }
+    
+    private boolean oaiFromUntilIntervalValid(String from, String until) {
+       try {
+         new OaiFromUntilInterval(from,until);
+       return true;
+     }
+     catch(Exception e) {
+         return false;
+     }
+    }
+    
+    
+    private OaiTargetDto getDayOnlyTarget()  {
+        
+        OaiTargetDto target= new OaiTargetDto();
+        target.setDayOnly(true);
+        target.setName("test day only target");
+        target.setDateStampFormat(DateStampFormatEnum.DATE);
+        target.setStartDay("2022-01-15");
+        return target;
+        
+        
+        
+    }
+    
     
 }

--- a/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
@@ -1,11 +1,16 @@
 package dk.kb.datahandler.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Calendar;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -52,6 +57,33 @@ public class HarvestTimeUtilTest {
         }
     }
     
-    //TODO validate date format
+
+    @Test
+    void testValidateDayFormat() throws Exception {
+    	assertTrue(HarvestTimeUtil.validateDayFormat("2024-01-01"));
+    	assertTrue(HarvestTimeUtil.validateDayFormat("2024-12-12"));
+    	assertFalse(HarvestTimeUtil.validateDayFormat("2024-02-31")); //31. feb does not exist
+    	
+    }
+
+    @Test
+    void testGetNextDay() throws Exception {    	
+    	    	
+    	assertEquals("2020-01-02",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-01-01")); //1 day
+    	assertEquals("2021-01-01",HarvestTimeUtil.getNextDayIfNot2DaysInFuture("2020-12-31")); //new year
+    
+        //Test 2 days in future
+    	//Construct today in format yyyy-MM-dd
+    	String today = HarvestTimeUtil.formatDate2Day(Calendar.getInstance().getTime());
+    	
+    	//Next day must be returned
+    	String tomorrow=HarvestTimeUtil.getNextDayIfNot2DaysInFuture(today);    	
+    	assertNotNull(tomorrow);    
+    	
+    	//This is 2 days in future.
+    	String todayPlus2Days = HarvestTimeUtil.getNextDayIfNot2DaysInFuture(tomorrow);
+    	assertNull(todayPlus2Days); //2 days in future     	    
+    }
+	
     
 }

--- a/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.ZoneId;
@@ -30,7 +31,8 @@ import dk.kb.datahandler.oai.OaiFromUntilInterval;
 public class HarvestTimeUtilTest {
 
     private static final Logger log = LoggerFactory.getLogger(HarvestTimeUtilTest.class);
-
+    private static final String DAY_PATTERN = "yyyy-MM-dd";
+    
     @Test
     void filePersistenceTest() throws Exception {
 
@@ -77,6 +79,7 @@ public class HarvestTimeUtilTest {
     	
     }
 
+     
     @Test
     void testGetNextDay() throws Exception {    	
     	    	
@@ -90,7 +93,7 @@ public class HarvestTimeUtilTest {
         //Test 2 days in future
     	//Construct today in format yyyy-MM-dd
     	Calendar cal = Calendar.getInstance(TimeZone.getDefault(),Locale.getDefault());
-    	String today = HarvestTimeUtil.formatDate2Day(cal.getTime());
+    	String today = formatDate2Day(cal.getTime());
     	
     	//Next day must be returned
     	String tomorrow=HarvestTimeUtil.getNextDayIfNot2DaysInFuture(today);    	
@@ -108,7 +111,7 @@ public class HarvestTimeUtilTest {
         OaiFromUntilInterval last = intervals.get(intervals.size()-1);        
         //'from' attribute in last interval must be today
         String mustBeToday = last.getFrom().substring(0,10);//Get day part
-        String today=HarvestTimeUtil.formatDate2Day(new Date());
+        String today=formatDate2Day(new Date());
         assertEquals(today,mustBeToday);        
     }
     
@@ -167,6 +170,16 @@ public class HarvestTimeUtilTest {
         return target;                
         
     }
-    
+    /**
+     * 
+     * From a java date format yyyy-MM-dd
+     * 
+     * @param date  Java date object
+     */
+    public static String formatDate2Day(Date date) {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DAY_PATTERN,Locale.ROOT);            
+        String day = simpleDateFormat.format(date);               
+        return day;        
+    }
     
 }

--- a/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/HarvestTimeUtilTest.java
@@ -89,4 +89,18 @@ public class HarvestTimeUtilTest {
     }
 	
     
+    @Test
+    void testUtcSecondsFormat() {
+                   
+        //All valid
+        assertTrue(HarvestTimeUtil.validateOaiDateFormat("2020-01-01T00:00:00Z"));
+        assertTrue(HarvestTimeUtil.validateOaiDateFormat("2021-03-24T19:57:34Z"));
+                
+        //Not valid
+        assertFalse(HarvestTimeUtil.validateOaiDateFormat("2021-03-32T19:57:34Z")); //day 32 does not exist
+        assertFalse(HarvestTimeUtil.validateOaiDateFormat("2021-03-24"));
+        assertFalse(HarvestTimeUtil.validateOaiDateFormat("2021-03-24T19:57:34.00.00Z"));
+        assertFalse(HarvestTimeUtil.validateOaiDateFormat("2021-03-24T19:57:34.00.000Z"));         
+    }
+    
 }


### PR DESCRIPTION
Pvica now always batch 1 day at a time and always use ISO date format. (since it gives the most results...)
The datestamp return from pvica that is saved in last harvest time file will also be reformatted from ISO+millis to ISO.

If the day only format is given it will be reformatted to ISO date. The reverse situation happens for our own COP harvesting. The "fixing" code is done same place.

Code changes:
OAI target (yaml configuration) has two new attributes 
day_only:  If true the harvest will always be batched in days.
start_day: If defined this will be first harvest day, also for full import. This is to avoid killing Sigfreds machines when starting full import from API page.

The full import method will now identify OAI targets with day_only and batch them instead.
