### PR TITLE
Commit of DISC-831. Split status and job list into two methods

### DIFF
--- a/src/main/openapi/ds-datahandler-openapi_v1.yaml
+++ b/src/main/openapi/ds-datahandler-openapi_v1.yaml
@@ -199,6 +199,27 @@ paths:
               schema:
                 type: string
 
+
+  /monitor/jobs:
+    get:
+      tags:
+        - Service
+      summary: 'List of running and past jobs'
+      operationId: jobs
+      responses:
+        '200':
+          description: 'List of jobs both running and completed since server start. Sorted by most recent jobs first. Still running jobs first'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OaiJobList'
+        '500':
+          description: 'Internal Error'
+          content:
+            text/plain:
+              schema:
+                type: string
+
 components:
   schemas:
 
@@ -238,8 +259,6 @@ components:
           type: string
           description: 'Self diagnosed health'
           example: 'ok'
-        jobs:
-          $ref: '#/components/schemas/OaiJobList'
         gitCommitChecksum:
           type: string
           description: 'The checksum of the deployed commit.'


### PR DESCRIPTION
Deployed on devel11
Extract the job list from the status method into a new method that only return jobs.

New jobs method can be testet on openAPI or by calling: http://devel11:10001/ds-datahandler/v1/monitor/jobs
(I started two jobs so list is not empty)

Status method (now without jobs):
http://devel11:10001/ds-datahandler/v1/monitor/status



