### PR TITLE
DRA-103 implemented. Integration tag for unittests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Moved OAI job list out into a new method '/monitor/jobs' It was part of the 'monitor/status' method before.
-
+- Bumb sb-parent to v.25
+- Added 'integration' tag to some unittests.
 
 ### Added
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.sbforge</groupId>
         <artifactId>sbforge-parent</artifactId>
-        <version>24</version>
+        <version>25</version>
     </parent>
 
     <groupId>dk.kb.datahandler</groupId>

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaUploadFolderIntegrationTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaUploadFolderIntegrationTest.java
@@ -29,17 +29,18 @@ public class KalturaUploadFolderIntegrationTest {
      *
      * Before running this method, change log-level to warn i logback.test.xml to avoid spamming.
      *  
+     *    *
+     * This can not be changed to a unittest since it will modify Kaltura
      */
     public static void main(String[] args)  {
 
         String kalturaUrl= "https://kmc.kaltura.nordu.net";        
         String adminSecret = "XXXXXXXXXXXXXXXXXXXXXXxxx"; 
         Integer partnerId = 380; // Use this partner ID for DS project 
-        String userId = "teg@kb.dk"; //User must exist in kaltura.                 
+        String userId = "XXX@kb.dk"; //User must exist in kaltura.                 
 
         try {
             KalturaUploadClient client = new KalturaUploadClient(kalturaUrl,userId,partnerId,adminSecret);
-
 
            // String uploadFolder="/home/teg/kaltura_files/video/";
             //KalturaMediaType mediaType = KalturaMediaType.VIDEO;

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaUploadIntegrationTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaUploadIntegrationTest.java
@@ -2,6 +2,7 @@ package dk.kb.datahandler.kaltura;
 
 import com.kaltura.client.enums.KalturaMediaType;
 
+
 public class KalturaUploadIntegrationTest {
 
     /**
@@ -10,7 +11,8 @@ public class KalturaUploadIntegrationTest {
      * It can take up to 10 minutes before the upload has been transcoded and can be streamed.
      * 
      * To stream the uploaded file change the reference id in this html-file: src/test/resources/kaltura_test_play.html
-     * 
+     *
+     * This can not be changed to a unittest since it will modify Kaltura
      */
     public static void main(String[] args)  {
         try {
@@ -18,7 +20,7 @@ public class KalturaUploadIntegrationTest {
             String kalturaUrl= "https://kmc.kaltura.nordu.net";        
             String adminSecret = "XXXXXXXXXXXXXXXXXXXXXXXXX"; 
             Integer partnerId = 380; // Use this partner ID for DS project 
-            String userId = "teg@kb.dk"; //User must exist in kaltura.                 
+            String userId = "XXX@kb.dk"; //User must exist in kaltura.                 
             KalturaUploadClient client = new KalturaUploadClient(kalturaUrl,userId,partnerId,adminSecret);
 
             //Upload a file

--- a/src/test/java/dk/kb/datahandler/oai/InvalidXmlTest.java
+++ b/src/test/java/dk/kb/datahandler/oai/InvalidXmlTest.java
@@ -6,10 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -26,7 +24,6 @@ public class InvalidXmlTest {
 
     @Test
     void simpleInvalidXmlTest() throws Exception {
-
         //Loads a miminal xml with 1 invalid xml encoding character (decimal encoding)
         //This is already test in the KB-util, but seems important enough for a test to see you use it correct
         
@@ -54,9 +51,6 @@ public class InvalidXmlTest {
         }                 
         assertEquals("test!", text.trim()); //invalid encoding removed
     }
-
-    
-    
     
     /*
      * Parse the XML as UTF-8 (in header of XML samples).
@@ -81,5 +75,4 @@ public class InvalidXmlTest {
         return textElement.getTextContent();
     }
   
-
 }

--- a/src/test/java/dk/kb/datahandler/oai/OaiHarvestClientIntegrationTest.java
+++ b/src/test/java/dk/kb/datahandler/oai/OaiHarvestClientIntegrationTest.java
@@ -1,37 +1,43 @@
 package dk.kb.datahandler.oai;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import dk.kb.datahandler.facade.DsDatahandlerFacade;
 import dk.kb.datahandler.model.v1.OaiTargetDto;
 
 
-/*
- * This is an integration test that must be run manually.
+/**
+ * This is an integration test that will call an external OAI service.
+ * The unittest is marked with the integrationTest tag
  * 
  */
 public class OaiHarvestClientIntegrationTest {
 
 
-    public static  void main(String[] args) throws Exception {
-   
-        //example: http://www5.kb.dk/cop/oai/?metadataPrefix=mods&set=oai:kb.dk:images:billed:2010:okt:billeder&verb=ListRecords
+    @Tag("integration")
+    @Test
+    void testHarvest1000OaiRecords() throws Exception {
 
-        // When using resumption token you must NOT include metadatPrefix+set again
+        //example: http://www5.kb.dk/cop/oai/?metadataPrefix=mods&set=oai:kb.dk:images:billed:2010:okt:billeder&verb=ListRecords
+        //When using resumption token you must NOT include metadatPrefix+set again
         //http://www5.kb.dk/cop/oai/?verb=ListRecords&resumptionToken=KB!1000!mods!0001-01-01!9999-12-31!oai:kb.dk:images:billed:2010:okt:billeder
-  
         
-        OaiTargetDto oaiTarget = new OaiTargetDto();
+        String set="oai:kb.dk:images:billed:2010:okt:billeder";
+        //String set="oai:kb.dk:images:billed:2014:jun:hca";
         
-        
-       oaiTarget.setUrl("http://www5.kb.dk/cop/oai/");
-       oaiTarget.setMetadataprefix("mods");               
-       oaiTarget.setSet("oai:kb.dk:images:billed:2010:okt:billeder");
-       oaiTarget.setUsername(null);
-       oaiTarget.setPassword(null);;
-       oaiTarget.setDatasource("test");
-       String from=null;
-       
+        OaiTargetDto oaiTarget = new OaiTargetDto();       
+        oaiTarget.setUrl("http://www5.kb.dk/cop/oai/"); //Public KB service
+        oaiTarget.setMetadataprefix("mods");               
+        oaiTarget.setSet(set);
+        oaiTarget.setUsername(null);
+        oaiTarget.setPassword(null);;
+        oaiTarget.setDatasource("test");
+        String from=null;
+
         /*
         String baseUrl="https://pvica-devel2.statsbiblioteket.dk/OAI-PMH/";
         String metadataPrefix="XIP_full_schema";               
@@ -39,28 +45,18 @@ public class OaiHarvestClientIntegrationTest {
         String user = "oai-pmh-devel";
         String password="XXXX"; //find it yourself
         String from ="2021-01-01";
-*/
-        
-        
-//       String set="oai:kb.dk:images:billed:2014:jun:hca";
-       OaiTargetJob job = DsDatahandlerFacade.createNewJob(oaiTarget);        
-       
-       OaiHarvestClient client = new OaiHarvestClient(job,from,null);
-       
-       OaiResponse r1 = client.next();
-       System.out.println("records:"+r1.getRecords().size());
-       System.out.println("token:"+r1.getResumptionToken());
-       
-   /*    
-       OaiResponse r2= client.next();
-       System.out.println(r2.getRecords().size());
-       
-       OaiResponse r3= client.next();
-       System.out.println(r3.getRecords().size());
-              */
-     
-        }
-   
+         */
 
+        OaiTargetJob job = DsDatahandlerFacade.createNewJob(oaiTarget);        
+
+        OaiHarvestClient client = new OaiHarvestClient(job,from,null);
+        OaiResponse r1 = client.next();
+        assertEquals(1000, r1.getRecords().size());
+        assertNotNull(r1.getResumptionToken());
+
+        //Fetch next 1000        
+        OaiResponse r2= client.next();
+        assertEquals(1000, r2.getRecords().size());
+    }
 
 }

--- a/src/test/java/dk/kb/datahandler/storageclient/StorageClientIntegrationTest.java
+++ b/src/test/java/dk/kb/datahandler/storageclient/StorageClientIntegrationTest.java
@@ -1,26 +1,35 @@
 package dk.kb.datahandler.storageclient;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import dk.kb.storage.invoker.v1.ApiException;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.util.DsStorageClient;
 
 
-/*
- * This is an integration test that must be run manually.
- *
+/**
+ *  Integration test, will not be run by automatic build flow.
  */
 public class StorageClientIntegrationTest{
 
-    
-    public static void main(String[] args) throws Exception {
-           	
-    	//replace server with a running server with ds-storage installed
-    	String backEndUrl="http://server:10001/ds-storage/v1/";
-    	
-        DsStorageClient client = new DsStorageClient(backEndUrl);            
-     
-        DsRecordDto record = client.getRecord("kb.image.luftfo.luftfoto:oai:kb.dk:images:luftfo:2011:maj:luftfoto:object187744");        
-        System.out.println(record);
+    private static final Logger log = LoggerFactory.getLogger(StorageClientIntegrationTest.class);
         
+    @Tag("integration")   
+    @Test
+    public void testDsStorage() throws ApiException {
+           	
+    	String backEndUrl="http://devel11:10001/ds-storage/v1/";    
+        DsStorageClient client = new DsStorageClient(backEndUrl);                 
+        String id = "kb.image.luftfo.luftfoto:oai:kb.dk:images:luftfo:2011:maj:luftfoto:object187744";
+        DsRecordDto record = client.getRecord(id);        
+        log.info("Loaded record from storage with id:"+record.getId());
+        assertEquals(id, "kb.image.luftfo.luftfoto:oai:kb.dk:images:luftfo:2011:maj:luftfoto:object187744");               
     }
     
 }

--- a/src/test/java/dk/kb/datahandler/util/DsDatahandlerClientTest.java
+++ b/src/test/java/dk/kb/datahandler/util/DsDatahandlerClientTest.java
@@ -14,21 +14,32 @@
  */
 package dk.kb.datahandler.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dk.kb.datahandler.invoker.v1.ApiException;
+import dk.kb.datahandler.model.v1.OaiTargetDto;
+
 /**
- * Simple verification of client code generation.
+ * Simple verification of client code generation. Integration test, will not be run by automatic build flow
  */
 public class DsDatahandlerClientTest {
     private static final Logger log = LoggerFactory.getLogger(DsDatahandlerClientTest.class);
-
-    // We cannot test usage as that would require a running instance of ds-datahandler to connect to
+       
+    @Tag("integration")
     @Test
-    public void testInstantiation() {
-        String backendURIString = "htp://example.com/ds-datahandler/v1";
+    public void testInstantiation() throws ApiException{
+        String backendURIString = "http://devel11:10001/ds-datahandler/v1";
         log.debug("Creating inactive client for ds-datahandler with URI '{}'", backendURIString);
-        new DsDatahandlerClient(backendURIString);
+        DsDatahandlerClient dsDatahandlerClient = new DsDatahandlerClient(backendURIString);
+        List<OaiTargetDto> targets = dsDatahandlerClient.getOaiTargetsConfiguration();
+        log.info("Integrationtest called oaiTargets on devel11. Number of targets:"+targets.size());
+        assertTrue(targets.size() >0);                
     }
 }


### PR DESCRIPTION
DRA-103 implemented. Integration tag for unittests.
POM parent upgraded to v25 that supports the new tags 'blocked' and 'integration'. 
'integration' tag added to two unittests.
