### PR TITLE
Dra 900 Add more logging when indexing to solr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <dependency>
         <groupId>dk.kb.present</groupId>
         <artifactId>ds-present</artifactId>
-          <version>1.7.4</version>
+          <version>1.8.0</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>


### PR DESCRIPTION
More logging: 
Implements the ability to log a warning when the size of the stream being indexed to solr is suspeciously tiny. (I've chosen the limit of 1000 bytes pr record. The average size of solr documents when indexing today is somewhere between 1400 and 1800 bytes.