### PR TITLE
Dra 1102 update manifestation enrichment with DOMS ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed how origin gets extracted from records to allow for xml namespace prefixes on the field being used for this filtering for Preservica records. 
 - Kaltura client implementation. Using ds-kaltura client as dependency instead.https://kb-dk.atlassian.net/browse/DRA-964
 - Bumped KB-util version
+- Updated endpoint ```enrichment/manifestations``` to check if records without ContentObjects are migrated from DOMS. If so, referenceId should be the same as the InformationObject ID. 
 
 ### Removed
 - Removed Preservica 5 data filter.

--- a/src/main/java/dk/kb/datahandler/preservica/PreservicaManifestationExtractor.java
+++ b/src/main/java/dk/kb/datahandler/preservica/PreservicaManifestationExtractor.java
@@ -1,8 +1,5 @@
 package dk.kb.datahandler.preservica;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.kb.datahandler.preservica.client.DsPreservicaClient;
 import dk.kb.datahandler.util.PreservicaUtils;
 import dk.kb.storage.model.v1.DsRecordDto;
@@ -10,16 +7,7 @@ import dk.kb.storage.model.v1.RecordTypeDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  *
@@ -43,7 +31,7 @@ public class PreservicaManifestationExtractor {
             // Get the clean Preservica InformationObject ID.
             String preservicaIoID = PreservicaUtils.getPreservicaIoId(dsRecord);
             // Extract filename from Preservica and create a prefixed version for DS.
-            String filename = DsPreservicaClient.getInstance().getFileRefFromInformationObject(preservicaIoID);
+            String filename = DsPreservicaClient.getInstance().getFileRefFromInformationObjectAsStream(preservicaIoID);
 
             // Update the record that is to be returned.
             if (!filename.isEmpty()){

--- a/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
+++ b/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.kb.datahandler.preservica.AccessResponseObject;
 import dk.kb.datahandler.util.PreservicaUtils;
 import org.apache.http.client.utils.URIBuilder;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,30 +205,6 @@ public class DsPreservicaClient {
     }
 
     /**
-     * Call the Object Details endpoint in the Preservica Content API for properties related to a specific InformationObject.
-     * @param id of the InformationObject to retrieve.
-     * @return An input stream containing the Object Details JSON response.
-     */
-    public InputStream getPreservicaObjectDetails(String id) throws IOException, URISyntaxException {
-        StringBuilder idBuilder = new StringBuilder();
-        URL url = new URIBuilder(baseUrl)
-                .setPathSegments(objectDetailsEndpoint)
-                // This ID needs to be prefixed with the string: sdb:IO|
-                .addParameter("id", idBuilder.append("sdb:IO|").append(id).toString())
-                .build()
-                .toURL();
-
-        log.debug("Opening connection to url: '{}'", url);
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
-        connection.setRequestMethod("GET");
-        connection.setRequestProperty("accept", "application/json");
-        connection.setRequestProperty("Preservica-Access-Token", accessToken);
-
-        return connection.getInputStream();
-    }
-
-    /**
      * Get the fileRef for the newest access representation for an InformationObject.
      * This method makes two distinct calls to the Preservica API. First it gets the ID of the newest access ContentObject
      * for the given InformationObject. Then the fileRef for the underlying Generation/Bitstream for the resolved
@@ -237,7 +212,7 @@ public class DsPreservicaClient {
      * @param id of the InformationObject to resolve.
      * @return a fileRef ID representing the filename of the representation on the server.
      */
-    public String getFileRefFromInformationObject(String id){
+    public String getFileRefFromInformationObjectAsStream(String id){
         InputStream accesRepresentationXml;
         String contentObjectId = "";
 
@@ -294,7 +269,7 @@ public class DsPreservicaClient {
      * @param id of the information object to retrieve identifiers for.
      * @return an input stream containing the response from the API.
      */
-    public InputStream getIdentifiers(String id) throws URISyntaxException, IOException{
+    public InputStream getIdentifiersAsStream(String id) throws URISyntaxException, IOException{
         List<String> getInformationObjectIdentifiersEndpoint = List.of("api", "entity", "information-objects", id, "identifiers");
 
         return getApiResponseAsInputStream(id, getInformationObjectIdentifiersEndpoint);
@@ -304,14 +279,13 @@ public class DsPreservicaClient {
      * @param id of the information object to retrieve.
      * @return the information object as an InputStream.
      */
-    public InputStream getInformationObject(String id) throws URISyntaxException, IOException {
+    public InputStream getInformationObjectAsStream(String id) throws URISyntaxException, IOException {
         List<String> getInformationObjectEndpoint = List.of("api", "entity", "information-objects", id);
 
         return getApiResponseAsInputStream(id, getInformationObjectEndpoint);
     }
 
 
-    @Nullable
     private InputStream getApiResponseAsInputStream(String id, List<String> getIoAccesRepresentationEndpoint) throws URISyntaxException, IOException {
         URL url = new URIBuilder(baseUrl)
                 .setPathSegments(getIoAccesRepresentationEndpoint)

--- a/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
+++ b/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
@@ -18,8 +18,9 @@ import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
+
+import static dk.kb.datahandler.util.PreservicaUtils.validateInformationObjectForDomsData;
 
 /**
  * Client for accessing Preservica 7. Currently, provides access to the Object-Details endpoint of the Content API.
@@ -243,8 +244,8 @@ public class DsPreservicaClient {
             accesRepresentationXml = getAccessRepresentationForIO(id);
             contentObjectId = PreservicaUtils.parseRepresentationResponseForContentObject(accesRepresentationXml);
         } catch (FileNotFoundException e){
-            log.info("No Access Content Object has been found for InformationObject: '{}'", id);
-            return "";
+            // Record could be a DOMS record. Extract Identifiers from InformationObject to check if that's the case.
+            return validateInformationObjectForDomsData(id);
         } catch (XMLStreamException | IOException | URISyntaxException e) {
             log.warn("Error getting or parsing ContentObject for InformationObject: '{}'", id, e);
         }

--- a/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
+++ b/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
@@ -318,4 +318,64 @@ public class DsPreservicaClient {
         return connection.getInputStream();
     }
 
+    /**
+     * Call the endpoint {@code /api/entity/information-objects/{id}/identifiers}
+     * @param id of the information object to retrieve identifiers for.
+     * @return an input stream containing the response from the API.
+     */
+    public InputStream getIdentifiers(String id) throws URISyntaxException, IOException{
+        List<String> getIoAccesRepresentationEndpoint = List.of("api", "entity", "information-objects", id, "identifiers");
+
+        URL url = new URIBuilder(baseUrl)
+                .setPathSegments(getIoAccesRepresentationEndpoint)
+                .build()
+                .toURL();
+
+        HttpURLConnection connection = null;
+        try {
+            log.debug("Opening connection to url: '{}'", url);
+            connection = (HttpURLConnection) url.openConnection();
+
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("accept", "application/xml");
+            connection.setRequestProperty("Preservica-Access-Token", accessToken);
+
+        } catch (FileNotFoundException e){
+            log.warn("No Access Content Object was found for InformationObject: '{}'", id);
+            return null;
+        }
+
+        return connection.getInputStream();
+    }
+
+    /**
+     *  Call the endpoint {@code /api/entity/information-objects/{id}}
+     * @param id of the information object to retrieve.
+     * @return the information object as an InputStream.
+     */
+    public InputStream getInformationObject(String id) throws URISyntaxException, IOException {
+        List<String> getIoAccesRepresentationEndpoint = List.of("api", "entity", "information-objects", id);
+
+        URL url = new URIBuilder(baseUrl)
+                .setPathSegments(getIoAccesRepresentationEndpoint)
+                .build()
+                .toURL();
+
+        HttpURLConnection connection = null;
+        try {
+            log.debug("Opening connection to url: '{}'", url);
+            connection = (HttpURLConnection) url.openConnection();
+
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("accept", "application/xml");
+            connection.setRequestProperty("Preservica-Access-Token", accessToken);
+
+        } catch (FileNotFoundException e){
+            log.warn("No Access Content Object was found for InformationObject: '{}'", id);
+            return null;
+        }
+
+        return connection.getInputStream();
+    }
+
 }

--- a/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
+++ b/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.kb.datahandler.preservica.AccessResponseObject;
 import dk.kb.datahandler.util.PreservicaUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -274,26 +275,7 @@ public class DsPreservicaClient {
     public InputStream getAccessRepresentationForIO(String id) throws IOException, URISyntaxException {
         List<String> getIoAccesRepresentationEndpoint = List.of("api", "entity", "information-objects", id, "representations", "Access");
 
-        URL url = new URIBuilder(baseUrl)
-                .setPathSegments(getIoAccesRepresentationEndpoint)
-                .build()
-                .toURL();
-
-        HttpURLConnection connection = null;
-        try {
-            log.debug("Opening connection to url: '{}'", url);
-            connection = (HttpURLConnection) url.openConnection();
-
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("accept", "application/xml");
-            connection.setRequestProperty("Preservica-Access-Token", accessToken);
-
-        } catch (FileNotFoundException e){
-            log.warn("No Access Content Object was found for InformationObject: '{}'", id);
-            return null;
-        }
-
-        return connection.getInputStream();
+        return getApiResponseAsInputStream(id, getIoAccesRepresentationEndpoint);
     }
 
     /**
@@ -304,19 +286,7 @@ public class DsPreservicaClient {
     public InputStream getFileRefForContentObject(String id) throws IOException, URISyntaxException {
         List<String> getFileRefForContentObjectEndpoint = List.of("api", "entity", "content-objects", id, "identifiers");
 
-        URL url = new URIBuilder(baseUrl)
-                .setPathSegments(getFileRefForContentObjectEndpoint)
-                .build()
-                .toURL();
-
-        log.debug("Opening connection to url: '{}'", url);
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
-        connection.setRequestMethod("GET");
-        connection.setRequestProperty("accept", "application/xml");
-        connection.setRequestProperty("Preservica-Access-Token", accessToken);
-
-        return connection.getInputStream();
+        return getApiResponseAsInputStream(id, getFileRefForContentObjectEndpoint);
     }
 
     /**
@@ -325,38 +295,24 @@ public class DsPreservicaClient {
      * @return an input stream containing the response from the API.
      */
     public InputStream getIdentifiers(String id) throws URISyntaxException, IOException{
-        List<String> getIoAccesRepresentationEndpoint = List.of("api", "entity", "information-objects", id, "identifiers");
+        List<String> getInformationObjectIdentifiersEndpoint = List.of("api", "entity", "information-objects", id, "identifiers");
 
-        URL url = new URIBuilder(baseUrl)
-                .setPathSegments(getIoAccesRepresentationEndpoint)
-                .build()
-                .toURL();
-
-        HttpURLConnection connection = null;
-        try {
-            log.debug("Opening connection to url: '{}'", url);
-            connection = (HttpURLConnection) url.openConnection();
-
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("accept", "application/xml");
-            connection.setRequestProperty("Preservica-Access-Token", accessToken);
-
-        } catch (FileNotFoundException e){
-            log.warn("No Access Content Object was found for InformationObject: '{}'", id);
-            return null;
-        }
-
-        return connection.getInputStream();
+        return getApiResponseAsInputStream(id, getInformationObjectIdentifiersEndpoint);
     }
-
     /**
      *  Call the endpoint {@code /api/entity/information-objects/{id}}
      * @param id of the information object to retrieve.
      * @return the information object as an InputStream.
      */
     public InputStream getInformationObject(String id) throws URISyntaxException, IOException {
-        List<String> getIoAccesRepresentationEndpoint = List.of("api", "entity", "information-objects", id);
+        List<String> getInformationObjectEndpoint = List.of("api", "entity", "information-objects", id);
 
+        return getApiResponseAsInputStream(id, getInformationObjectEndpoint);
+    }
+
+
+    @Nullable
+    private InputStream getApiResponseAsInputStream(String id, List<String> getIoAccesRepresentationEndpoint) throws URISyntaxException, IOException {
         URL url = new URIBuilder(baseUrl)
                 .setPathSegments(getIoAccesRepresentationEndpoint)
                 .build()
@@ -372,7 +328,7 @@ public class DsPreservicaClient {
             connection.setRequestProperty("Preservica-Access-Token", accessToken);
 
         } catch (FileNotFoundException e){
-            log.warn("No Access Content Object was found for InformationObject: '{}'", id);
+            log.warn("No response could be found for id: '{}'", id);
             return null;
         }
 

--- a/src/main/java/dk/kb/datahandler/util/PreservicaUtils.java
+++ b/src/main/java/dk/kb/datahandler/util/PreservicaUtils.java
@@ -227,7 +227,7 @@ public class PreservicaUtils {
      */
     public static boolean checkForDomsRecord(String id){
         try {
-            InputStream identifiersResponse = DsPreservicaClient.getInstance().getIdentifiers(id);
+            InputStream identifiersResponse = DsPreservicaClient.getInstance().getIdentifiersAsStream(id);
 
             // Create an XMLEventReader
             XMLInputFactory factory = XMLInputFactory.newInstance();

--- a/src/test/java/dk/kb/datahandler/preservica/PreservicaClientTest.java
+++ b/src/test/java/dk/kb/datahandler/preservica/PreservicaClientTest.java
@@ -33,7 +33,7 @@ public class PreservicaClientTest {
     public void testManifestationExtractionForDoms() throws IOException {
         // ID of a DOMS record. Has no ContentObject as of 11th of July 2024.
         String informationObjectId = "6ca25068-6dd4-45ed-a0cb-ab808441c078";
-        String result = DsPreservicaClient.getInstance().getFileRefFromInformationObject(informationObjectId);
+        String result = DsPreservicaClient.getInstance().getFileRefFromInformationObjectAsStream(informationObjectId);
 
         assertEquals(informationObjectId, result);
     }
@@ -70,7 +70,7 @@ public class PreservicaClientTest {
     @Test
     public void testGetFileRefFromIO() throws IOException {
         // Newest ContentObject at 28th of May 2024. This can change in the future.
-        String fileRef = DsPreservicaClient.getInstance().getFileRefFromInformationObject("ee36a7b5-de87-4e45-96d8-018b513a5e2e");
+        String fileRef = DsPreservicaClient.getInstance().getFileRefFromInformationObjectAsStream("ee36a7b5-de87-4e45-96d8-018b513a5e2e");
         assertEquals("ce4a81eb-ab15-474f-bed5-0debc2fde97a", fileRef);
     }
 
@@ -78,7 +78,7 @@ public class PreservicaClientTest {
     @Test
     public void testNoFileRefFromIO() throws IOException {
         // Newest ContentObject at 28th of May 2024. This can change in the future.
-        String fileRef = DsPreservicaClient.getInstance().getFileRefFromInformationObject("abee9c4f-dacd-4518-b68b-773c8506ac7d");
+        String fileRef = DsPreservicaClient.getInstance().getFileRefFromInformationObjectAsStream("abee9c4f-dacd-4518-b68b-773c8506ac7d");
         assertEquals("", fileRef);
     }
 

--- a/src/test/java/dk/kb/datahandler/preservica/PreservicaClientTest.java
+++ b/src/test/java/dk/kb/datahandler/preservica/PreservicaClientTest.java
@@ -28,6 +28,16 @@ public class PreservicaClientTest {
                 ServiceConfig.getPreservicaPassword(), ServiceConfig.getPreservicaKeepAliveSeconds());
     }
 
+
+    @Test
+    public void testManifestationExtractionForDoms() throws IOException {
+        // ID of a DOMS record. Has no ContentObject as of 11th of July 2024.
+        String informationObjectId = "6ca25068-6dd4-45ed-a0cb-ab808441c078";
+        String result = DsPreservicaClient.getInstance().getFileRefFromInformationObject(informationObjectId);
+
+        assertEquals(informationObjectId, result);
+    }
+
     @Test
     public void testCreateManifestationFromDsRecord() throws IOException {
         PreservicaManifestationExtractor manifestationPlugin = new PreservicaManifestationExtractor();


### PR DESCRIPTION
When no ContentObject has been found for record. An identifier lookup is made to see if the record is a DOMS record. If yes, the id is used as referenceId.

One question for you: Should the referenceId be appended with either .mp4 or .mp3 or are these values not added to the files in kaltura. They are present in the filenames on our server.