### PR TITLE
Change storage client method used in methods not requiring record.data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed 
+- Changed DSStorage client method used in methods DsDatahandlerFacade.updateManifestationForRecords and DsDatahandlerFacade.fetchKalturaIdsAndUpdateRecords.
+- Bumped ds-storage dependency to v. 2.1.1
 
 ### Removed
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <dependency>
         <groupId>dk.kb.storage</groupId>
         <artifactId>ds-storage</artifactId>
-          <version>2.0.0</version>
+          <version>2.1.1</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/src/main/java/dk/kb/datahandler/preservica/PreservicaManifestationExtractor.java
+++ b/src/main/java/dk/kb/datahandler/preservica/PreservicaManifestationExtractor.java
@@ -3,6 +3,7 @@ package dk.kb.datahandler.preservica;
 import dk.kb.datahandler.preservica.client.DsPreservicaClient;
 import dk.kb.datahandler.util.PreservicaUtils;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,11 +23,7 @@ public class PreservicaManifestationExtractor {
      * is about will be resolved from the backing Preservica instance and added as a referenceId in the record it has been applied to.
      * @param dsRecord DeliverableUnit to fetch manifestation from.
      */
-    public DsRecordDto apply(DsRecordDto dsRecord) {
-        if (dsRecord.getRecordType() != RecordTypeDto.DELIVERABLEUNIT){
-            log.warn("Manifestation extraction plugin has been used on a record which cant have manifestations.");
-            return null;
-        }
+    public DsRecordMinimalDto apply(DsRecordMinimalDto dsRecord) {
         try {
             // Get the clean Preservica InformationObject ID.
             String preservicaIoID = PreservicaUtils.getPreservicaIoId(dsRecord);

--- a/src/test/java/dk/kb/datahandler/preservica/PreservicaClientTest.java
+++ b/src/test/java/dk/kb/datahandler/preservica/PreservicaClientTest.java
@@ -4,8 +4,7 @@ import dk.kb.datahandler.config.ServiceConfig;
 
 import dk.kb.datahandler.preservica.client.DsPreservicaClient;
 import dk.kb.datahandler.util.PreservicaUtils;
-import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.RecordTypeDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ public class PreservicaClientTest {
     @Test
     public void testCreateManifestationFromDsRecord() throws IOException {
         PreservicaManifestationExtractor manifestationPlugin = new PreservicaManifestationExtractor();
-        DsRecordDto record = getTestRecord();
+        DsRecordMinimalDto record = getTestRecord();
         record = manifestationPlugin.apply(record);
 
         assertEquals("21f85387-9900-4f2a-ab4f-cf81b2fd1dea", record.getReferenceId());
@@ -87,7 +86,7 @@ public class PreservicaClientTest {
     @Test
     public void testRefresh() throws IOException, InterruptedException {
         PreservicaManifestationExtractor manifestationPlugin = new PreservicaManifestationExtractor();
-        DsRecordDto record = getTestRecord();
+        DsRecordMinimalDto record = getTestRecord();
         record = manifestationPlugin.apply(record);
 
         assertEquals("21f85387-9900-4f2a-ab4f-cf81b2fd1dea", record.getReferenceId());
@@ -99,9 +98,8 @@ public class PreservicaClientTest {
         assertEquals("21f85387-9900-4f2a-ab4f-cf81b2fd1dea", record.getReferenceId());
     }
 
-    private static DsRecordDto getTestRecord() {
-        DsRecordDto record = new DsRecordDto();
-        record.setRecordType(RecordTypeDto.DELIVERABLEUNIT);
+    private static DsRecordMinimalDto getTestRecord() {
+        DsRecordMinimalDto record = new DsRecordMinimalDto();
         record.setId("ds.tv:oai:io:9e081b87-66f4-4797-9cff-d2ce226ab300");
         return record;
     }

--- a/src/test/java/dk/kb/datahandler/util/PreservicaUtilTest.java
+++ b/src/test/java/dk/kb/datahandler/util/PreservicaUtilTest.java
@@ -1,6 +1,7 @@
 package dk.kb.datahandler.util;
 
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PreservicaUtilTest {
     @Test
     public void testPreservicaIdExtraction(){
-        DsRecordDto testRecord = new DsRecordDto();
+        DsRecordMinimalDto testRecord = new DsRecordMinimalDto();
         testRecord.setId("ds.tv:oai:io:3006e2f8-3f73-477a-a504-4d7cb1ae1e1c");
 
         String preservicaId = PreservicaUtils.getPreservicaIoId(testRecord);


### PR DESCRIPTION
Changed storage method used in methods not working with record.data. 

deployed on devel. Tested the kaltura endpoint, needing the list of records, works as intended. 