### PR TITLE
Use kaltura appTokens instead of mastersecret.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Upgraded ds-kaltura to v.1.2.4
+- Upgraded ds-kaltura to v.1.2.5
 - Kaltura client uses kaltura app-tokens instead of mastersecret. Two new properties added: kaltura.token and katura.tokenId. Mastersecret can be set to null in property
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Kaltura client uses kaltura app-tokens instead of mastersecret. Two new properties added: kaltura.token and katura.tokenId. Mastersecret can be set to null in property
 
 ## [1.9.7](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-1.9.7) - 2024-10-03 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Upgraded ds-kaltura to v.1.2.4
 - Kaltura client uses kaltura app-tokens instead of mastersecret. Two new properties added: kaltura.token and katura.tokenId. Mastersecret can be set to null in property
+
 
 ## [1.9.7](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-1.9.7) - 2024-10-03 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
       <dependency>
           <groupId>dk.kb.kaltura</groupId>
           <artifactId>ds-kaltura</artifactId>
-          <version>1.2.4</version>
+          <version>1.2.5</version>
           <type>jar</type>
       </dependency>
         

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
       <dependency>
           <groupId>dk.kb.kaltura</groupId>
           <artifactId>ds-kaltura</artifactId>
-          <version>1.2.3</version>
+          <version>1.2.4</version>
           <type>jar</type>
       </dependency>
         

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -413,10 +413,7 @@ public class DsDatahandlerFacade {
         String tokenId= ServiceConfig.getConfig().getString("kaltura.tokenId");
        
         long sessionKeepAliveSeconds=3600L; //1 hour
-        log.info("creating kaltura client for partnerID:"+partnerId);
-        log.info("secret:"+adminSecret);
-        log.info("token:"+token);
-        log.info("tokenId:"+tokenId);
+        log.info("creating kaltura client for partnerID:"+partnerId);     
         DsKalturaClient kalturaClient = new DsKalturaClient(kalturaUrl,userId,partnerId,token,tokenId,adminSecret,sessionKeepAliveSeconds);
         return kalturaClient;
     }

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ForkJoinTask;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.ZipEntry;
@@ -408,12 +406,18 @@ public class DsDatahandlerFacade {
 
     private static DsKalturaClient getKalturaClient() throws IOException {
         String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
-        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed.
+        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed. Use token,tokenId.
         Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
         String userId = ServiceConfig.getConfig().getString("kaltura.userId");                               
+        String token= ServiceConfig.getConfig().getString("kaltura.token");
+        String tokenId= ServiceConfig.getConfig().getString("kaltura.tokenId");
+       
         long sessionKeepAliveSeconds=3600L; //1 hour
         log.info("creating kaltura client for partnerID:"+partnerId);
-        DsKalturaClient kalturaClient = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret,sessionKeepAliveSeconds);
+        log.info("secret:"+adminSecret);
+        log.info("token:"+token);
+        log.info("tokenId:"+tokenId);
+        DsKalturaClient kalturaClient = new DsKalturaClient(kalturaUrl,userId,partnerId,token,tokenId,adminSecret,sessionKeepAliveSeconds);
         return kalturaClient;
     }
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaManualDeleteJob.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaManualDeleteJob.java
@@ -27,16 +27,18 @@ public class KalturaManualDeleteJob {
     public static void main(String[] args) {
         
         String kalturaUrl = "https://kmc.kaltura.nordu.net";
-        String adminSecret = "XXXXXXXXXXXXXXXXXXXXXXxxx";
-        Integer partnerId = 397; // This is production kaltura! Test is 399 and stage is 398 and production is 397
-        String userId = "XXX@kb.dk"; // User must exist in kaltura.
+        String adminSecret = null;// Use token,tokenId  instead
+        Integer partnerId = 398; // 398=stage, 397=prod. 
+        String userId = "XXX@kb.dk"; //User must exist in kaltura.                 
+        String token="abc"; // <- replace with correct token matching tokenId
+        String tokenId="0_f2qyxk5i";
 
         String input_entry_ids = "/home/xxx/kaltura_entryids_to_delete.txt"; // File with entryIds til be delete. One oneeach line
         String output_entry_ids = "/home/xxx/kaltura_entryids_delete_failed.txt"; // EntryIds that failed during deletion will be added in this file.
         try {
             createNewFileIfNotExists(output_entry_ids); // Will create new if not exists;
 
-            DsKalturaClient client = new DsKalturaClient(kalturaUrl, userId, partnerId, adminSecret, 86400);
+            DsKalturaClient client = new DsKalturaClient(kalturaUrl, userId, partnerId, token,tokenId,adminSecret, 86400);
             int numberDeleteFailed = 0;
             int numberDeleteSuccess = 0;
             List<String> entryIds = readAllLines(input_entry_ids);

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaManualFileUploader.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaManualFileUploader.java
@@ -35,12 +35,14 @@ public class KalturaManualFileUploader {
     public static void main(String[] args)  {
 
         String kalturaUrl= "https://kmc.kaltura.nordu.net";        
-        String adminSecret = "XXXXXXXXXXXXXXXXXXXXXXxxx"; 
-        Integer partnerId = 380; // Use this partner ID for DS project 
+        String adminSecret = null;// Use token,tokenId  instead
+        Integer partnerId = 398; // 398=stage, 397=prod. 
         String userId = "XXX@kb.dk"; //User must exist in kaltura.                 
-
+        String token="abc"; // <- replace with correct token matching tokenId
+        String tokenId="0_f2qyxk5i";
+        
         try {
-            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret,86400);            
+            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,token,tokenId,adminSecret,86400);            
 
            // String uploadFolder="/home/teg/kaltura_files/video/";
             //KalturaMediaType mediaType = KalturaMediaType.VIDEO;

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaUploadFolderIntegrationTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaUploadFolderIntegrationTest.java
@@ -37,12 +37,14 @@ public class KalturaUploadFolderIntegrationTest {
     public static void main(String[] args)  {
 
         String kalturaUrl= "https://kmc.kaltura.nordu.net";        
-        String adminSecret = "XXXXXXXXXXXXXXXXXXXXXXxxx"; 
-        Integer partnerId = 380; // Use this partner ID for DS project 
+        String adminSecret = null;// Use token,tokenId instead
+        Integer partnerId = 398; // 398=stage, 397=prod. 
         String userId = "XXX@kb.dk"; //User must exist in kaltura.                 
-
+        String token="abc"; // <- replace with correct token matching tokenId
+        String tokenId="0_f2qyxk5i";
+        
         try {
-            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret,86400);
+            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,token,tokenId,adminSecret,86400);
 
            // String uploadFolder="/home/teg/kaltura_files/video/";
             //KalturaMediaType mediaType = KalturaMediaType.VIDEO;


### PR DESCRIPTION
Use kaltura app-tokens instead of mastersecret. Upgraded ds-kaltura  to v.1.2.4.

Reads two new properties:
kaltura.token
kaltura.tokenId

Mastersecret can be leaved blank.