### PR TITLE
Dra 1371 better manifestation logging and performance boost in enrichment endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added better logging of what actually happens during enrichment methods.
 
 
 ## [1.10.1](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-1.10.1) - 2024-10-15

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -475,7 +475,8 @@ public class DsDatahandlerFacade {
         // Create a custom ForkJoinPool with configured amount of threads
         int numberOfThreads = ServiceConfig.getPreservicaThreads();
         ForkJoinPool customThreadPool = new ForkJoinPool(numberOfThreads);
-        log.info("");
+        log.info("Created a custom thread-pool containing '{}' threads. Using this pool of threads to query Preservica for manifestation IDs for records with origin: '{}'",
+                numberOfThreads, origin);
 
         while (hasMore) {
             try (ContinuationInputStream<Long> dsDocsStream =

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -73,7 +73,8 @@ public class DsDatahandlerFacade {
      * 
      * 
      */
-    public static long fetchKalturaIdsAndUpdateRecords(String origin,Long mTimeFrom) throws Exception{
+    public static long fetchKalturaIdsAndUpdateRecords(String origin,Long mTimeFrom) throws Exception {
+        log.info("Starting resolving of Kaltura entry ID's for origin: '{}'", origin);
         if (mTimeFrom== null) {
             mTimeFrom=0L;
         }
@@ -93,7 +94,7 @@ public class DsDatahandlerFacade {
                 break;
             }
             mTimeFrom=records.get(records.size()-1).getmTime(); //update mTime to mTime from last record.
-            log.debug("Getting DsRecordReference from storage for origin={},batchSize={},mTimeFrom={}",origin,batchSize,mTimeFrom);
+            log.debug("Getting DsRecordMinimal from storage for origin={}, batchSize={}, mTimeFrom={}", origin, batchSize, mTimeFrom);
             
             ArrayList<String> referenceIdsList= new ArrayList<String>();
             for (DsRecordMinimalDto record: records) {
@@ -105,14 +106,15 @@ public class DsDatahandlerFacade {
                 continue;
             }
 
-            log.debug("Calling Kaltura to resolve kalturaId for referenceIds. Size:"+referenceIdsList.size());
+            log.debug("Calling Kaltura to resolve kalturaId for referenceIds. Calling with a batch of '{}' records.", referenceIdsList.size());
             Map<String, String> kalturaIds = kalturaClient.getKulturaIds(referenceIdsList);
 
             if (kalturaIds.size() != referenceIdsList.size()) {
-                log.warn("Not all referenceId was found at Kaltura"); //Should not happen
+                log.warn("Not all referenceIds was found at Kaltura"); //Should not happen
             }
             updated+=kalturaIds.size();      
-            
+
+            log.debug("Updating '{}' mappings in the DS-Storage mapping table, which handles relations between referenceIds and kalturaIds.", kalturaIds.size());
             for (String referenceId: kalturaIds.keySet()) {                            
                 //Can be optimized with method that takes multiple. But this workflow is called rarely.             
                 MappingDto mappingDto= new MappingDto();
@@ -123,8 +125,10 @@ public class DsDatahandlerFacade {
         }        
 
         //Mapping table is now updated. Enrich all records that does not have KalturaId
+        log.debug("Updating kaltura ID for ALL records.");
         dsAPI.updateKalturaIdForRecords();//Will update all records with kalturaid using the mapping tab
-        log.info("Updated kalturaId mapping table and enriched records. Number of mapppings updated:"+updated +" millis:"+(System.currentTimeMillis()-start));
+        log.info("Updated kalturaId mapping table and enriched records. Number of records updated is: '{}'. The full request lasted '{}' milliseconds.",
+                updated , (System.currentTimeMillis() - start));
         return updated;
     }
 
@@ -471,6 +475,7 @@ public class DsDatahandlerFacade {
         // Create a custom ForkJoinPool with configured amount of threads
         int numberOfThreads = ServiceConfig.getPreservicaThreads();
         ForkJoinPool customThreadPool = new ForkJoinPool(numberOfThreads);
+        log.info("");
 
         while (hasMore) {
             try (ContinuationInputStream<Long> dsDocsStream =

--- a/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
+++ b/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
@@ -223,7 +223,7 @@ public class DsPreservicaClient {
      * @param id of the InformationObject to resolve.
      * @return a fileRef ID representing the filename of the representation on the server.
      */
-    public String getFileRefFromInformationObjectAsStream(String id) throws InterruptedException {
+    public String getFileRefFromInformationObjectAsStream(String id) throws InterruptedException, IOException {
         InputStream accessRepresentationXml = InputStream.nullInputStream();
         String contentObjectId = "";
 
@@ -248,6 +248,8 @@ public class DsPreservicaClient {
             }
         } catch (XMLStreamException | IOException e) {
             log.error("Error parsing ContentObject for Preservica InformationObject: '{}'", id, e);
+        } finally {
+            accessRepresentationXml.close();
         }
 
 
@@ -271,6 +273,8 @@ public class DsPreservicaClient {
             }
         } catch (XMLStreamException | IOException e) {
             log.warn("Error parsing fileRef for ContentObject: '{}'", contentObjectId, e);
+        } finally {
+            fileRefXml.close();
         }
 
         return fileRef;

--- a/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
+++ b/src/main/java/dk/kb/datahandler/preservica/client/DsPreservicaClient.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.StringJoiner;
 
 import static dk.kb.datahandler.util.PreservicaUtils.validateInformationObjectForDomsData;
 import static java.lang.Thread.sleep;
@@ -218,16 +219,17 @@ public class DsPreservicaClient {
      * Get the fileRef for the newest access representation for an InformationObject.
      * This method makes two distinct calls to the Preservica API. First it gets the ID of the newest access ContentObject
      * for the given InformationObject. Then the fileRef for the underlying Generation/Bitstream for the resolved
-     * ContentObject is resolved.
+     * ContentObject is resolved. If no ContentObject is available the method checks if the record in hand is a DOMS record and extracts the access copy it this way.
      * @param id of the InformationObject to resolve.
      * @return a fileRef ID representing the filename of the representation on the server.
      */
     public String getFileRefFromInformationObjectAsStream(String id) throws InterruptedException {
-        InputStream accesRepresentationXml = InputStream.nullInputStream();
+        InputStream accessRepresentationXml = InputStream.nullInputStream();
         String contentObjectId = "";
 
         try {
-            accesRepresentationXml = getAccessRepresentationForIO(id);
+            // Get the newest access representation for an InformationObject if any is present.
+            accessRepresentationXml = getAccessRepresentationForIO(id);
         } catch (FileNotFoundException e){
             // Record could be a DOMS record. Extract Identifiers from InformationObject to check if that's the case.
             return validateInformationObjectForDomsData(id);
@@ -235,30 +237,35 @@ public class DsPreservicaClient {
             log.warn("Error getting ContentObject for InformationObject: '{}'", id, e);
         }
 
+        // If the record is migrated from DOMS, the code would have returned the ID already.
+        // The following part of the method only gets executed for "native" Preservica records.
+        log.debug("The record in hand is a native preservica record. FileRef now gets extracted from ContentObject.");
         try {
-            if (accesRepresentationXml.available() != 0) {
-                log.info("Stream has '{}' bytes available", accesRepresentationXml.available());
-                contentObjectId = PreservicaUtils.parseRepresentationResponseForContentObject(accesRepresentationXml);
+            // Parse AccessRepresentation XML for ContentObject ID.
+            if (accessRepresentationXml.available() != 0) {
+                log.debug("Access Representation XML stream has '{}' bytes available", accessRepresentationXml.available());
+                contentObjectId = PreservicaUtils.parseRepresentationResponseForContentObject(accessRepresentationXml);
             }
         } catch (XMLStreamException | IOException e) {
-            log.error("Error parsing ContentObject for InformationObject: '{}'", id, e);
+            log.error("Error parsing ContentObject for Preservica InformationObject: '{}'", id, e);
         }
 
 
         InputStream fileRefXml = InputStream.nullInputStream();
         String fileRef = "";
         try {
+            // Get fileRef XML for ContentObject.
             fileRefXml = getFileRefForContentObject(contentObjectId);
         } catch (FileNotFoundException e){
             // Should not happen
-            log.warn("No fileRef has been found for ContentObject: '{}'", contentObjectId);
+            log.warn("No fileRef has been found for ContentObject: '{}'. Returning an empty string.", contentObjectId);
             return "";
         } catch (IOException | URISyntaxException e) {
-            log.warn("Error getting fileRef for ContentObject: '{}'", contentObjectId, e);
+            log.warn("Error getting fileRef for Preservica ContentObject: '{}'", contentObjectId, e);
         }
 
-
         try {
+            // Parse fileRef XML for the correct fileRef, which is the ID of the presentation copy on the internal filesystem.
             if (fileRefXml.available() != 0){
                 fileRef = PreservicaUtils.parseIdentifierResponseForFileRef(fileRefXml);
             }
@@ -334,18 +341,30 @@ public class DsPreservicaClient {
                 connection.setRequestProperty("Preservica-Access-Token", accessToken);
                 return connection.getInputStream();
             } catch (FileNotFoundException e){
-                log.info("No response could be found for id: '{}'.", id);
+                log.debug("No response could be found for id: '{}' when querying endpoint: '{}'.", id, getEndpointString(preservicaEndpointPathElements));
                 throw e;
             } catch (IOException e){
                 currentTry ++;
-                log.error("Received a time out from Preservica when querying for record with ID: '{}'. Retrying in 10 seconds, this is the '{}' retry of '{}'",
-                        id, currentTry, maxTries);
+                log.error("Received a time out from Preservica when querying for record with ID: '{}'. Retrying in '{}' seconds, this is the '{}' retry of '{}'",
+                        id, retrySeconds, currentTry, maxTries);
                 sleep(retrySeconds * 1000L); //Sleeping for X seconds before retrying.
                 DsPreservicaClient.getInstance();
             }
         }
 
         throw new InternalServiceException("No response could be obtained for URL: '" + url + "'.");
+    }
+
+    /**
+     * Convert a list of endpoint path elements to a string representation of the endpoint.
+     * @param preservicaEndpointPathElements to create full endpoint string from.
+     * @return a string representation of the endpoint.
+     */
+    private String getEndpointString(List<String> preservicaEndpointPathElements) {
+        StringJoiner joiner = new StringJoiner("/", "/", "");
+        preservicaEndpointPathElements.forEach(joiner::add);
+
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/dk/kb/datahandler/util/PreservicaUtils.java
+++ b/src/main/java/dk/kb/datahandler/util/PreservicaUtils.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class PreservicaUtils {
 
     private static final Logger log = LoggerFactory.getLogger(PreservicaUtils.class);
+    private static final XMLInputFactory factory = XMLInputFactory.newInstance();
 
     /**
      * Initialize a {@link PreservicaManifestationExtractor} which fetches a presentation representation through the
@@ -91,7 +92,6 @@ public class PreservicaUtils {
      */
     public static String parseRepresentationResponseForContentObject(InputStream xml) throws XMLStreamException {
         // Create an XMLEventReader
-        XMLInputFactory factory = XMLInputFactory.newInstance();
         XMLEventReader eventReader = factory.createXMLEventReader(xml);
 
         // Variables to hold data
@@ -134,6 +134,7 @@ public class PreservicaUtils {
             }
         }
 
+        eventReader.close();
         return contentObject;
     }
 
@@ -147,7 +148,6 @@ public class PreservicaUtils {
      */
     public static String parseIdentifierResponseForFileRef(InputStream xml) throws XMLStreamException {
         // Create an XMLEventReader
-        XMLInputFactory factory = XMLInputFactory.newInstance();
         XMLEventReader eventReader = factory.createXMLEventReader(xml);
 
         // Variables to hold data
@@ -198,6 +198,7 @@ public class PreservicaUtils {
             }
         }
 
+        eventReader.close();
         return fileRef;
     }
 
@@ -232,11 +233,9 @@ public class PreservicaUtils {
      * @return true if input InformationObject has been migrated from DOMS. Otherwise, false.
      */
     public static boolean checkForDomsRecord(String id) throws InterruptedException {
-        try {
-            InputStream identifiersResponse = DsPreservicaClient.getInstance().getIdentifiersAsStream(id);
+        try (InputStream identifiersResponse = DsPreservicaClient.getInstance().getIdentifiersAsStream(id)){
 
             // Create an XMLEventReader
-            XMLInputFactory factory = XMLInputFactory.newInstance();
             XMLEventReader eventReader = factory.createXMLEventReader(identifiersResponse);
 
             // Variables to hold data
@@ -283,6 +282,7 @@ public class PreservicaUtils {
                     }
                 }
             }
+            eventReader.close();
             return sourceId.startsWith("doms");
         } catch (URISyntaxException | IOException | XMLStreamException e) {
             throw new InternalServiceException(e);

--- a/src/main/java/dk/kb/datahandler/util/PreservicaUtils.java
+++ b/src/main/java/dk/kb/datahandler/util/PreservicaUtils.java
@@ -216,9 +216,11 @@ public class PreservicaUtils {
         if (isDomsRecord){
             // If the record is a DOMS record and there are no Access Content Objects. The fileRef should be set as
             // the InformationObject ID.
+            log.info("Record with ID: '{}' is a DOMS record. Setting UUID as reference ID.", id);
             return id;
         } else {
-            log.info("No Access Content Object has been found for InformationObject: '{}'", id);
+            log.info("No Access Content Object has been found for Preservica InformationObject with ID: '{}'. This record probably haven't been transcoded. Returning an empty " +
+                    "string", id);
             return "";
         }
     }

--- a/src/test/java/dk/kb/datahandler/preservica/client/PreservicaClientTest.java
+++ b/src/test/java/dk/kb/datahandler/preservica/client/PreservicaClientTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -100,6 +101,29 @@ public class PreservicaClientTest {
         // Newest ContentObject at 28th of May 2024. This can change in the future.
         String fileRef = DsPreservicaClient.getInstance().getFileRefFromInformationObjectAsStream("abee9c4f-dacd-4518-b68b-773c8506ac7d");
         assertEquals("", fileRef);
+    }
+
+    @Tag("integration")
+    @Test
+    public void testDOMSCheck() throws IOException, InterruptedException {
+        String id1 = "f37d60da-6b29-4d4f-9b18-50c45e9157a8";
+        String id2 = "ab438f89-1baf-441e-91de-568068e8f406";
+        String id3 = "689e2fff-e2db-47e8-ba16-6719a8616b38";
+        List<String> ids = List.of(id1, id2, id3);
+
+        for (int i = 0; i < 300; i++) {
+
+            ids.forEach( id ->
+                    {
+                        try {
+                            String result = PreservicaUtils.validateInformationObjectForDomsData(id);
+                            assertEquals(id, result);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+        }
     }
 
     @Tag("slow")

--- a/src/test/java/dk/kb/datahandler/preservica/client/PreservicaClientTest.java
+++ b/src/test/java/dk/kb/datahandler/preservica/client/PreservicaClientTest.java
@@ -103,16 +103,20 @@ public class PreservicaClientTest {
         assertEquals("", fileRef);
     }
 
+    @Tag("slow")
     @Tag("integration")
     @Test
-    public void testDOMSCheck() throws IOException, InterruptedException {
+    public void testDOMSCheck() {
+        // Test used for profiling connection to preservica and parsing response objects.
+
+        // When I did profiling I set this variable to 10000.
+        int amountOfRuns = 1000;
         String id1 = "f37d60da-6b29-4d4f-9b18-50c45e9157a8";
         String id2 = "ab438f89-1baf-441e-91de-568068e8f406";
         String id3 = "689e2fff-e2db-47e8-ba16-6719a8616b38";
         List<String> ids = List.of(id1, id2, id3);
 
-        for (int i = 0; i < 300; i++) {
-
+        for (int i = 0; i < amountOfRuns; i++) {
             ids.forEach( id ->
                     {
                         try {
@@ -124,6 +128,9 @@ public class PreservicaClientTest {
                     }
             );
         }
+
+        // Used as breakpoint to start and run the test with the debugger attached to have a look at  object in memory over time
+        System.out.println("finished");
     }
 
     @Tag("slow")


### PR DESCRIPTION
This was supposed to only be a pull request on making log messages more telling for the manifestation enrichment endpoint. However the recent events of slow crunch time made me look into some performance as well. I believe I've found a bit of a performance increase. Compared to master, this branch runs the added test approx. 20% faster. I also made sure that opened and used inputstream were indeed correctly closed. Memory usage for manifestation enrichment seems to spike less as well, se attached pictures:

**Memory usage for profiling test on master**
![Screenshot from 2024-10-17 14-54-45](https://github.com/user-attachments/assets/7e9136f2-9e38-40a4-98bb-9469093e1df7)

**Memory usage for profiling test on this branch**
![Screenshot from 2024-10-18 08-35-05](https://github.com/user-attachments/assets/c1316b5c-df05-4788-9907-7e78b54a2ab1)
