### PR TITLE
Dra 1373 remove duplicated code from preservica filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Refactored OAI Response filters, to remove duplicate code from Preservica and DR filter
 ### Fixed
 
 ## [1.11.0](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-1.11.0) - 2025-03-05

--- a/src/main/java/dk/kb/datahandler/oai/OaiResponseFilterDrArchive.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiResponseFilterDrArchive.java
@@ -65,25 +65,11 @@ public class OaiResponseFilterDrArchive extends OaiResponseFilterPreservicaSeven
             }
 
             // InformationObjects from preservica 7 need to have the PBCore metadata tag.
-            Matcher metadataMatcher = METADATA_PATTERN.matcher(xml);
-            if ((recordId.contains("oai:io")) && !metadataMatcher.find()) {
-                processed++;
-                emptyMetadataRecords ++;
-                log.warn("OAI-PMH record '{}' does not contain PBCore metadata and is therefore not added to storage. " +
-                                "'{}' empty records have been found and '{}' records have been processed in total.",
-                        recordId, emptyMetadataRecords, processed);
+            if (!informationObjectContainsPbcoreBoolean(xml, recordId)){
                 continue;
             }
 
-            Matcher transcodingDoneMatcher = TRANSCODING_PATTERN.matcher(xml);
-            if (!transcodingDoneMatcher.find()) {
-                processed++;
-                transCodingNotDoneRecords++;
-                log.debug("OAI-PMH record '{}' transcoding status not done. Record skipped",recordId);
-                if (transCodingNotDoneRecords % 1000 == 0) {
-                    log.info("'{}' records transcoding status not done filtered away. '{}' records have been processed.",
-                            transCodingNotDoneRecords, processed);
-                }
+            if (!transcodingStatusIsDoneBoolean(xml, recordId)){
                 continue;
             }
 


### PR DESCRIPTION
This is an old one. I found a way to not have the code duplicated. Will probably be changed again, when we remove the string parsing of XML.