### PR TITLE
Dra 1950 admin secret as failsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- KalturaDeltaUploadJob will now use kaltura.adminSecret if present.
 
 ## [3.0.2](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-3.0.2) - 2025-07-07
 ### Changed

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -208,6 +208,7 @@ kaltura:
   url:  'XX'
   partnerId:  xxx
   userId:  'xxx@kb.dk'
+  adminSecret: ''
   token: 'XXXX'
   tokenId: 'XXX'
   sessionDurationSeconds: 86400

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -208,7 +208,6 @@ kaltura:
   url:  'XX'
   partnerId:  xxx
   userId:  'xxx@kb.dk'
-  adminSecret: 'xxxxxxx'
   token: 'XXXX'
   tokenId: 'XXX'
   sessionDurationSeconds: 86400

--- a/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/datahandler/config/ServiceConfig.java
@@ -107,7 +107,8 @@ public class ServiceConfig {
         kalturaToken = ServiceConfig.getConfig().getString("kaltura.token");
         kalturaTokenId = ServiceConfig.getConfig().getString("kaltura.tokenId");
         //Do not use kaltura adminsecret, use token and tokenId instead.
-        kalturaAdminSecret= ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed. Use token,tokenId.
+        //Must not be shared or exposed. Use token,tokenId.
+        kalturaAdminSecret= ServiceConfig.getConfig().getString("kaltura.adminSecret", "");
       
         
         kalturaSessionDurationSeconds = ServiceConfig.getConfig().getInteger("kaltura.sessionDurationSeconds", 86400);

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -338,7 +338,7 @@ public class KalturaDeltaUploadJob {
 
         String kalturaUrl = ServiceConfig.getKalturaUrl();
         Integer partnerId = ServiceConfig.getKalturaPartnerId();
-        String adminSecret = null;// We use appTokens instead
+        String adminSecret = ServiceConfig.getKalturaAdminSecret();
         String userId = ServiceConfig.getKalturaUserId();
         String token = ServiceConfig.getKalturaToken();
         String tokenId = ServiceConfig.getKalturaTokenId();


### PR DESCRIPTION
ds-kaltura is build to take a secret if present. However, ds-datahandler sets adminSecret to null no matter what. This PR changes this so that the adminSecret can be added to the conf environment yaml as a failsafe if appToken sessions ever fails again.

This change is related to DRA-1950