### PR TITLE
Clear up unittest so it can build without aegis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ds-datahandler will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Clear up unittest so it can build without aegis. Added properties to default-behaviour and marked one unittest as integration since it require aegis.
+
+
 ## [4.0.0](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-4.0.0) - 2026-01-29
 
 ### Added

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,23 +38,6 @@ pipeline {
             }
         }
 
-        stage('Checkout aegis and copy files') {
-            steps {
-                dir('aegis') {
-                    checkout scmGit(
-                        branches: [[name: 'refs/heads/master']],
-                        userRemoteConfigs: [[
-                            credentialsId: 'kb-dk-jenkins-github-app',
-                            url: 'https://github.com/kb-dk/aegis.git'
-                        ]]
-                    )
-                }
-
-                sh "cp --recursive aegis/ds-datahandler/local/src/test/resources/. src/test/resources/."
-                sh "rm --recursive aegis"
-            }
-        }
-
         stage('Change version if part of PR') {
             when {
                 expression {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -37,23 +37,6 @@ pipeline {
             }
         }
 
-        stage('Checkout aegis and copy files') {
-            steps {
-                dir('aegis') {
-                    checkout scmGit(
-                        branches: [[name: 'refs/heads/master']],
-                        userRemoteConfigs: [[
-                            credentialsId: 'kb-dk-jenkins-github-app',
-                            url: 'https://github.com/kb-dk/aegis.git'
-                        ]]
-                    )
-                }
-
-                sh "cp --recursive aegis/ds-datahandler/local/src/test/resources/. src/test/resources/."
-                sh "rm --recursive aegis"
-            }
-        }
-
         stage("Change version") {
             steps {
                 withMaven(options: [artifactsPublisher(fingerprintFilesDisabled: true, archiveFilesDisabled: true)], traceability: true, mavenLocalRepo: "${WORKSPACE}/repository") {

--- a/conf/ds-datahandler-behaviour.yaml
+++ b/conf/ds-datahandler-behaviour.yaml
@@ -143,7 +143,15 @@ oaiTargets:
     metadataPrefix: XIP_full_schema
     description: Radio- og TV-udsendelser
     filter: dr
-    fragmentServiceUrl: https://nifi-server.kb.dk
+
+  - name: 'test.target'
+    datasource: ds.radiotv
+    url: https://pvica-devel2.statsbiblioteket.dk/OAI-PMH/
+    user: ''
+    password: ''
+    metadataPrefix: XIP_full_schema
+    description: Radio- of TV-udsendelser
+
 
 # Settings for OAI-PMH harvest
 oaiSettings:
@@ -204,6 +212,7 @@ present:
 
 # Kaltura properties. Use token+tokenId as credentials instead of admin-secret. 
 # The two flavour params depend on the kaltura partnerId. The values 3 and 359 match stage and prod kaltura.
+# If called by integration test, the integration next needs to load the integration unittest property file (from aegis) and also mark test as integrationtesdt
 kaltura:
   url:  'XX'
   partnerId:  399
@@ -213,8 +222,8 @@ kaltura:
   tokenId: 'XXX'
   sessionDurationSeconds: 86400
   sessionRefreshThreshold: 3600
-  conversionProfileIdAudio: 'XXXXX'
-  conversionProfileIdVideo: 'XXXXX'
+  conversionProfileIdAudio: '1234'
+  conversionProfileIdVideo: '1234'
   conversionQueueThreshold: 50
   conversionQueueDelaySeconds: 30
 

--- a/src/test/java/dk/kb/datahandler/facade/DsDatahandlerFacadeTest.java
+++ b/src/test/java/dk/kb/datahandler/facade/DsDatahandlerFacadeTest.java
@@ -30,8 +30,7 @@ public class DsDatahandlerFacadeTest {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        ServiceConfig.initialize("ds-datahandler-unittest.yaml");
-
+        ServiceConfig.initialize("conf/ds-datahandler-behaviour.yaml");
         H2DbUtil.createEmptyH2DBFromDDL(DB_URL, DRIVER, USERNAME, PASSWORD);
         JobStorage.initialize(DRIVER, DB_URL, USERNAME, PASSWORD);
 

--- a/src/test/java/dk/kb/datahandler/preservica/PreservicaDataTest.java
+++ b/src/test/java/dk/kb/datahandler/preservica/PreservicaDataTest.java
@@ -6,6 +6,8 @@ import dk.kb.datahandler.util.PreservicaOaiRecordHandler;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.util.Resolver;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -22,6 +24,7 @@ import java.util.ArrayList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("integration")
 public class PreservicaDataTest {
     static final SAXParserFactory factory = SAXParserFactory.newInstance();
 
@@ -110,56 +113,5 @@ public class PreservicaDataTest {
         assertEquals("ds.test", dsRecord.getOrigin());
     }
 
-    /**
-     * Create an OAI test response containing two InformationObjects.
-     * @return OAI Response with two fake IO records.
-     */
-    private static OaiResponse createTestOaiResponseWithIOs() {
-        // Create OAI-PMH test records.
-        OaiRecord informationObject1 = new OaiRecord();
-        informationObject1.setId("oai:io:12345678-test-test-test-testtest1111");
-        informationObject1.setMetadata("<Metadata schemaUri=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\">"+
-                "<formatMediaType>Sound</formatMediaType>");
-        OaiRecord informationObject22 = new OaiRecord();
-        informationObject22.setId("oai:io:12345678-test-test-test-testtest2222");
-        informationObject22.setMetadata("<Metadata schemaUri=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\">"+
-                "<formatMediaType>Sound</formatMediaType>");
-
-        ArrayList<OaiRecord> oaiRecords = new ArrayList<>();
-        oaiRecords.add(informationObject1);
-        oaiRecords.add(informationObject22);
-        // Create test OaiResponse.
-        OaiResponse testResponse = new OaiResponse();
-        testResponse.setRecords(oaiRecords);
-        return testResponse;
-    }
-
-    private static OaiResponse createPreserviceFiveOaiResponse() {
-        // Create OAI-PMH test records.
-        OaiRecord deliverableUnit1 = new OaiRecord();
-
-        deliverableUnit1.setId("oai:du:12345678-test-test-test-testtest1111");
-        deliverableUnit1.setMetadata("<Metadata schemaURI=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\">"+
-                "<formatMediaType>Sound</formatMediaType>");
-        OaiRecord deliverableUnit2 = new OaiRecord();
-        deliverableUnit2.setId("oai:du:12345678-test-test-test-testtest2222");
-        deliverableUnit2.setMetadata("<Metadata schemaURI=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\">"+
-                "<formatMediaType>Sound</formatMediaType>");
-        OaiRecord preservationManifestation = new OaiRecord();
-        preservationManifestation.setId("oai:man:12345678-test-test-test-testtest2222");
-        preservationManifestation.setMetadata("<ManifestationRelRef>1</ManifestationRelRef>");
-        OaiRecord collection = new OaiRecord();
-        collection.setId("oai:col:123456-test-1234");
-        // Create ArrayList of OAI records.
-        ArrayList<OaiRecord> oaiRecords = new ArrayList<>();
-        oaiRecords.add(collection);
-        oaiRecords.add(deliverableUnit1);
-        oaiRecords.add(deliverableUnit2);
-        oaiRecords.add(preservationManifestation);
-        // Create test OaiResponse.
-        OaiResponse testResponse = new OaiResponse();
-        testResponse.setRecords(oaiRecords);
-        return testResponse;
-    }
 
 }

--- a/src/test/java/dk/kb/datahandler/storage/JobStorageTest.java
+++ b/src/test/java/dk/kb/datahandler/storage/JobStorageTest.java
@@ -31,7 +31,7 @@ public class JobStorageTest {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        ServiceConfig.initialize("ds-datahandler-unittest.yaml");
+        ServiceConfig.initialize("conf/ds-datahandler-behaviour.yaml");
 
         H2DbUtil.createEmptyH2DBFromDDL(DB_URL, DRIVER, USERNAME, PASSWORD);
         JobStorage.initialize(DRIVER, DB_URL, USERNAME, PASSWORD);


### PR DESCRIPTION
Added properties to default-behaviour and marked one unittest as integration since it require aegis.
One of the test that failed because property loader tried to load a property as integer, but the property in the default behavoir was 'XXXX', so this failed. The property was not even used in the test.

I made a clean checkout without calling kb init to fetch aegis files, and build was successfull.

One unitttest marked as integration test (PreservicaDataTest) since it require xml files from aegis.

This is a lttle lazy and should be anonymized so they can be be added to ds-datahandler. 
A general clean up of this will be very time consuming if also done in ds-present that has many xml files in aegis.






