### PR TITLE
DRA-2576: add enum `Source` that is used by kaltura upload and transcriptions in the job table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ds-datahandler will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-4.0.1) - 2026-03-02
+
+### Fixed
+
+- Add enum `Source` that is used by kaltura upload job and transcriptions job when it is saved in the `job` table 
+  instead of having null in source column. Fixes a bug with SQL that can not handle `source = ?`, when source is NULL.
+
 ## [4.0.0](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-4.0.0) - 2026-01-29
 
 ### Added

--- a/src/main/java/dk/kb/datahandler/enums/Source.java
+++ b/src/main/java/dk/kb/datahandler/enums/Source.java
@@ -1,0 +1,29 @@
+package dk.kb.datahandler.enums;
+
+public enum Source {
+    DR_ARCHIVE("dr_archive");
+
+    private String value;
+
+    private Source(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public String toString() {
+        return String.valueOf(this.value);
+    }
+
+    public static Source fromValue(String value) {
+        for(Source b : values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}

--- a/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
+++ b/src/main/java/dk/kb/datahandler/facade/DsDatahandlerFacade.java
@@ -13,6 +13,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import com.kaltura.client.types.APIException;
+import dk.kb.datahandler.enums.Source;
 import dk.kb.datahandler.model.v1.*;
 import dk.kb.datahandler.oai.OaiResponseFilterDrArchive;
 import dk.kb.datahandler.oai.OaiResponseFilterPreservicaSeven;
@@ -307,7 +308,7 @@ public class DsDatahandlerFacade {
         // mTimeFrom is in microseconds
         OffsetDateTime offsetDateModifiedTimeFrom = OffsetDateTime.ofInstant(Instant.EPOCH.plus(0, ChronoUnit.MICROS), ZoneOffset.UTC);
 
-        JobDto jobDto = startJob(TypeDto.DELTA, CategoryDto.KALTURA_UPLOAD, null, offsetDateModifiedTimeFrom, user);
+        JobDto jobDto = startJob(TypeDto.DELTA, CategoryDto.KALTURA_UPLOAD, Source.DR_ARCHIVE.getValue(), offsetDateModifiedTimeFrom, user);
 
         log.info("Starting kaltura delta upload");
         try {
@@ -344,7 +345,7 @@ public class DsDatahandlerFacade {
      * @return Number of successful transcriptions loaded
      */        
     public static Integer transcriptionsLoad(String user) throws Exception { 
-        JobDto jobDto = startJob(TypeDto.DELTA, CategoryDto.TRANSCRIPTIONS, null, null, user);        
+        JobDto jobDto = startJob(TypeDto.DELTA, CategoryDto.TRANSCRIPTIONS, Source.DR_ARCHIVE.getValue(), null, user);
         try {
           String dropFolder=ServiceConfig.getTranscriptionsDropFolder();
           String completedFolder=ServiceConfig.getTranscriptionsCompletedFolder();
@@ -572,7 +573,7 @@ public class DsDatahandlerFacade {
 
         UUID jobId = BasicStorage.performStorageAction(databaseMessage, JobStorage::new, (JobStorage storage) -> {
             if (storage.hasRunningJob(categoryDto, source)) {
-                throw new InvalidArgumentServiceException("There is already an OAI Harvest job running");
+                throw new InvalidArgumentServiceException("There is already a/an " + categoryDto + " job running");
             }
             return storage.createJob(jobDto);
         });

--- a/src/test/java/dk/kb/datahandler/facade/DsDatahandlerFacadeTest.java
+++ b/src/test/java/dk/kb/datahandler/facade/DsDatahandlerFacadeTest.java
@@ -1,6 +1,7 @@
 package dk.kb.datahandler.facade;
 
 import dk.kb.datahandler.config.ServiceConfig;
+import dk.kb.datahandler.enums.Source;
 import dk.kb.datahandler.model.v1.*;
 import dk.kb.datahandler.storage.BasicStorage;
 import dk.kb.datahandler.storage.JobStorage;
@@ -90,28 +91,57 @@ public class DsDatahandlerFacadeTest {
      * Can only have one job with the same name running at the same time even if one is a delta job and the other is a full job
      */
     @Test
-    void testOnly1JobWithSameName() {
-        OaiTargetDto oaiTarget = ServiceConfig.getOaiTargets().get("test.target");
-        
-        // OK
+    void startJob_whenThereIsAlreadyARunningKalturaUploadJob_thenThrowInvalidArgumentServiceException() {
+        // Arrange
+        String user = "Unit test user";
         JobDto jobDto = new JobDto();
+
         jobDto.setType(TypeDto.DELTA);
-        jobDto.category(CategoryDto.OAI_HARVEST);
-        jobDto.setSource(oaiTarget.getName());
-        jobDto.setCreatedBy("Unit test");
+        jobDto.category(CategoryDto.KALTURA_UPLOAD);
+        jobDto.setSource(Source.DR_ARCHIVE.getValue());
+        jobDto.setCreatedBy(user);
         jobDto.setJobStatus(JobStatusDto.RUNNING);
         jobDto.setStartTime(OffsetDateTime.now(ZoneOffset.UTC));
 
-        BasicStorage.performStorageAction("Create job for OAITest", JobStorage::new, (JobStorage storage) -> {
+        BasicStorage.performStorageAction("Create job for kaltura upload test", JobStorage::new, (JobStorage storage) -> {
             storage.createJob(jobDto);
             return null;
         });
 
-        // Try add another
+        // Act/Assert
         InvalidArgumentServiceException exception = Assertions.assertThrows(InvalidArgumentServiceException.class,
-                () -> DsDatahandlerFacade.oaiIngestFull(oaiTarget.getName(), "Unit test")
+                () -> DsDatahandlerFacade.kalturaDeltaUpload(user)
         );
 
-        Assertions.assertEquals("There is already an OAI Harvest job running", exception.getMessage());
+        Assertions.assertEquals("There is already a/an kaltura upload job running", exception.getMessage());
+    }
+
+    /**
+     * Can only have one job with the same name running at the same time even if one is a delta job and the other is a full job
+     */
+    @Test
+    void startJob_whenThereIsAlreadyRunningTranscriptionsJob_thenThrowInvalidArgumentServiceException() {
+        // Arrange
+        String user = "Unit test user";
+        JobDto jobDto = new JobDto();
+
+        jobDto.setType(TypeDto.DELTA);
+        jobDto.category(CategoryDto.TRANSCRIPTIONS);
+        jobDto.setSource(Source.DR_ARCHIVE.getValue());
+        jobDto.setCreatedBy(user);
+        jobDto.setJobStatus(JobStatusDto.RUNNING);
+        jobDto.setStartTime(OffsetDateTime.now(ZoneOffset.UTC));
+
+        BasicStorage.performStorageAction("Create job for transcriptions test", JobStorage::new, (JobStorage storage) -> {
+            storage.createJob(jobDto);
+            return null;
+        });
+
+        // Act/Assert
+        InvalidArgumentServiceException exception = Assertions.assertThrows(InvalidArgumentServiceException.class,
+                () -> DsDatahandlerFacade.transcriptionsLoad(user)
+        );
+
+        Assertions.assertEquals("There is already a/an transcriptions job running", exception.getMessage());
     }
 }

--- a/src/test/java/dk/kb/datahandler/storage/JobStorageTest.java
+++ b/src/test/java/dk/kb/datahandler/storage/JobStorageTest.java
@@ -1,6 +1,7 @@
 package dk.kb.datahandler.storage;
 
 import dk.kb.datahandler.config.ServiceConfig;
+import dk.kb.datahandler.enums.Source;
 import dk.kb.datahandler.model.v1.CategoryDto;
 import dk.kb.datahandler.model.v1.JobDto;
 import dk.kb.datahandler.model.v1.JobStatusDto;
@@ -139,19 +140,25 @@ public class JobStorageTest {
     }
 
     @Test
-    public void testHasJobRunning() throws SQLException {
-        JobDto jobDto = genetrateJobDto();
+    public void hasRunningJob_whenSourceHasValue_thenReturnTrue() throws SQLException {
+        // Arrange
+        JobDto jobDto = new JobDto();
 
-        // No OAI_HARVEST job should be running
-        assertFalse(storage.hasRunningJob(CategoryDto.OAI_HARVEST, "test.source"));
-
-        jobDto.setCategory(CategoryDto.OAI_HARVEST);
-        jobDto.setSource("test.source");
+        jobDto.setType(TypeDto.DELTA);
+        jobDto.category(CategoryDto.KALTURA_UPLOAD);
+        jobDto.setSource(Source.DR_ARCHIVE.getValue());
+        jobDto.setCreatedBy("Unit test user");
         jobDto.setJobStatus(JobStatusDto.RUNNING);
+        jobDto.setStartTime(OffsetDateTime.now(ZoneOffset.UTC));
+
+        // Verify that no job of the same type is running
+        assertFalse(storage.hasRunningJob(CategoryDto.KALTURA_UPLOAD, Source.DR_ARCHIVE.getValue()));
+
+        // Act
         storage.createJob(jobDto);
 
-        // Now there should be a OIA_HARVEST job running
-        assertTrue(storage.hasRunningJob(CategoryDto.OAI_HARVEST, "test.source"));
+        // Assert
+        assertTrue(storage.hasRunningJob(CategoryDto.KALTURA_UPLOAD, Source.DR_ARCHIVE.getValue()));
     }
 
     @Test


### PR DESCRIPTION
- Add enum `Source` that is used by kaltura upload job and transcriptions job when it is saved in the `job` table instead of having null in source column. Fixes a bug with SQL that can not handle `source = ?`, when source is NULL.