### PR TITLE
Dra 2602 casesensitive match on format media type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,13 +35,7 @@ hs_err_pid*
 
 # Contains username and password for test instance
 oai_harvest.conf
-/src/test/resources/xml/4f706cda-f474-46c8-824b-5a62ed5a8bee.xml
-/src/test/resources/xml/054c55b3-ed3a-442c-99dd-1b80c0218114.xml
-/src/test/resources/xml/twoprofiles.xml
-/src/test/resources/xml/updatedprofileswithrecord.xml
-/src/test/resources/xml/08909897-cf37-4bd9-a230-1b48c87cea18.xml
-/src/test/resources/xml/aaa668c2-bf17-4ce7-bf24-d0ff5d29d097.xml
-/src/test/resources/xml/ebcbe76b-f130-4093-baa6-127fc7558fc5.xml
+/src/test/resources/xml/*.xml
 /src/test/resources/audio/NoisyPillars.mp3
 
 # We use pom.xml as the source of truth and don't rely on a specific IDE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to ds-datahandler will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Casesensitive match on mediaType, only accept 'Moving Image' as tv and 'Sound' as radio.
+
 ## [4.0.1](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-4.0.1) - 2026-03-02
 
 ### Fixed

--- a/src/main/java/dk/kb/datahandler/oai/OaiResponseFilterPreservicaSeven.java
+++ b/src/main/java/dk/kb/datahandler/oai/OaiResponseFilterPreservicaSeven.java
@@ -122,6 +122,7 @@ public class OaiResponseFilterPreservicaSeven extends OaiResponseFilter{
             case RADIO:
                 return "ds.radio";
             case UNKNOWN:
+                log.warn("Record type is UNKNOWN, setting origin to empty string for record: {} ", oaiRecord.getId());
                 return "";
             default:
                 throw new InternalServiceException("Unknown record type: " + preservicaRecordHandler.getRecordType());

--- a/src/main/java/dk/kb/datahandler/util/PreservicaOaiRecordHandler.java
+++ b/src/main/java/dk/kb/datahandler/util/PreservicaOaiRecordHandler.java
@@ -158,16 +158,16 @@ public class PreservicaOaiRecordHandler extends DefaultHandler {
 
         if (cleanQName.equalsIgnoreCase("formatMediaType")) {
             // Check what type of record we have in hand
-            switch (formatMediaTypeContent.toString().toLowerCase(Locale.ROOT)) {
-                case "moving image":
+            switch (formatMediaTypeContent.toString()) {
+                case "Moving Image":
                     recordType = RecordType.TV;
                     break;
-                case "sound":
+                case "Sound":
                     recordType = RecordType.RADIO;
                     break;
                 default:
                     recordType = RecordType.UNKNOWN;
-                    log.error("No recordType could be found for the record. Record cannot be sorted into a DS origin.");
+                    log.error("No recordType could be found for record with and formatMediaType:'{}'. Record type set to UNKNOWN", formatMediaTypeContent.toString());
             }
 
             isFormatMediaType = false; // reset flag

--- a/src/test/java/dk/kb/datahandler/oai/OaiRecordHandlerTest.java
+++ b/src/test/java/dk/kb/datahandler/oai/OaiRecordHandlerTest.java
@@ -86,4 +86,21 @@ public class OaiRecordHandlerTest {
         saxParser.parse(Resolver.resolveStream("xml/updatedprofileswithrecord.xml"), handler);
         assertEquals("ed685674-cc4e-44e3-8556-8d83010482aa", handler.fileId);
     }
+
+    @Test
+    public void testValidFormatMediaType() throws ParserConfigurationException, SAXException, IOException {
+        SAXParser saxParser = factory.newSAXParser();
+        PreservicaOaiRecordHandler handler = new PreservicaOaiRecordHandler();
+        saxParser.parse(Resolver.resolveStream("xml/054c55b3-ed3a-442c-99dd-1b80c0218114.xml"),handler);
+        assertEquals(PreservicaOaiRecordHandler.RecordType.TV, handler.getRecordType());
+    }
+
+    @Test
+    public void testInvalidFormatMediaType() throws ParserConfigurationException, SAXException, IOException {
+        SAXParser saxParser = factory.newSAXParser();
+        PreservicaOaiRecordHandler handler = new PreservicaOaiRecordHandler();
+        saxParser.parse(Resolver.resolveStream("xml/dc885d8e-2d11-4067-a2d6-d7df9add8331.xml"),handler);
+        assertEquals(PreservicaOaiRecordHandler.RecordType.UNKNOWN, handler.getRecordType());
+    }
+
 }


### PR DESCRIPTION
Only allow 'Moving Image' and 'Sound' (case sensitive) as mediatypes when harvesting 