### PR TITLE
DRA-2659-fix-deltaUpload-log-message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clear up unittest so it can build without aegis. Added properties to default-behaviour and marked one unittest as integration since it require aegis.
 - Removed API method that called ds-storage to enrich kaltura id from mapping table. (Mappe table has been deleted)
 - Changed processUpload to return number of streams uploaded (1 or 0) and removed the numberStreamsUploaded arg. uploadStreamsToKaltura now keeps track of the count of streams uploaded instead of trying to pass the var to processUpload to be updated.
+- Changed hasStreamFileError to return StreamErrorDto instead of String as stated in javadoc. 
 
 ## [4.0.2](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-4.0.2) - 2026-25-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Clear up unittest so it can build without aegis. Added properties to default-behaviour and marked one unittest as integration since it require aegis.
 - Removed API method that called ds-storage to enrich kaltura id from mapping table. (Mappe table has been deleted)
+- Changed processUpload to return number of streams uploaded (1 or 0) and removed the numberStreamsUploaded arg. uploadStreamsToKaltura now keeps track of the count of streams uploaded instead of trying to pass the var to processUpload to be updated.
 
 ## [4.0.2](https://github.com/kb-dk/ds-datahandler/releases/tag/ds-datahandler-4.0.2) - 2026-25-03
 

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -86,8 +86,9 @@ public class KalturaDeltaUploadJob {
             } catch (SolrServerException | IOException e) {
                 // Can not fetch more records. Stop delta upload
                 moreSolrRecords = false;
-                log.error("Could not fetch more solr records from mTime={}", mTimeFromCurrent);
-                throw new InternalServiceException(e.getMessage());
+                String errorMessage = "Could not fetch more solr records from mTime=" + mTimeFromCurrent;
+                log.error(errorMessage);
+                throw new InternalServiceException(errorMessage, e);
             }
             if (docs.getNumFound() == 0) {
                 return numberStreamsUploaded;
@@ -96,24 +97,25 @@ public class KalturaDeltaUploadJob {
             for (SolrDocument doc : docs) {
                 String resourceDescription = (String) doc.getFieldValue("resource_description");
 
-                String title = "";//Default
+                String title = ""; //Default
                 ArrayList<String> titles = (ArrayList<String>) doc.getFieldValue("title"); //multivalue
                 if (titles != null && titles.size() > 0) {
-                    title = titles.get(0);// take first
+                    title = titles.get(0); // take first
                 }
                 String description = (String) doc.getFieldValue("description");
                 String fileId = (String) doc.getFieldValue("file_id");
                 String filePathSolr = (String) doc.getFieldValue("file_path");
                 String originatesFrom = (String) doc.getFieldValue("originates_from");
                 String id = (String) doc.getFieldValue("id");
-                long recordMtime = (Long) doc.getFieldValue("internal_storage_mTime");
+                long recordMtime = (long) doc.getFieldValue("internal_storage_mTime");
                 String fileExtension = (String) doc.getFieldValue("file_extension");
-                String filePath;
-                try{
+                String filePath = null;
+                try {
                     filePath = KalturaUtil.generateStreamPath(filePathSolr, originatesFrom, resourceDescription);
-                }catch (IOException e){
-                    log.error("Could not generate stream path");
-                    throw new InternalServiceException(e.getMessage());
+                } catch (IOException e) {
+                    String errorMessage = "Could not generate stream path";
+                    log.error(errorMessage, e);
+                    throw new InternalServiceException(errorMessage, e);
                 }
 
                 mTimeFromCurrent = recordMtime + 1L; //update mTime for next call

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -138,16 +138,16 @@ public class KalturaDeltaUploadJob {
      * @return Number of streams uploaded (either 1 if stream uploaded or 0 if skipped)
      **/
     static int processUpload(String uploadTagForKaltura, long minimumFileSizeInBytes, DsStorageClient storageClient,
-                             String resourceDescription, String title, String description, String fileId, String id, String path,
+                             String resourceDescription, String title, String description, String fileId, String id, String filePath,
                              String fileExtension) {
         try {
             //upload stream
             MediaType mediaType = KalturaUtil.getMediaType(resourceDescription);
             int conversionProfileId = KalturaUtil.getGetConversionProfileId(mediaType);
-            log.info("validating stream='{}' with title='{}'", path, title);
-            StreamErrorTypeDto fileError = hasStreamFileError(path, minimumFileSizeInBytes);
+            log.info("validating stream='{}' with title='{}'", filePath, title);
+            StreamErrorTypeDto fileError = hasStreamFileError(filePath, minimumFileSizeInBytes);
             if (fileError != null) {
-                log.warn("File does not exist='{}' or size in bytes less than '{}'. Error='{}'. Id='{}'. Skipping upload", path, minimumFileSizeInBytes, fileError.getValue(), id);
+                log.warn("File does not exist='{}' or size in bytes less than '{}'. Error='{}'. Id='{}'. Skipping upload", filePath, minimumFileSizeInBytes, fileError.getValue(), id);
                 updateKalturaIdForRecord(storageClient, fileId, fileError.getValue());
                 return 0;
             }
@@ -161,15 +161,15 @@ public class KalturaDeltaUploadJob {
             }
 
             try {
-                String kalturaId = uploadStream(title, fileId, description, path, uploadTagForKaltura,
+                String kalturaId = uploadStream(title, fileId, description, filePath, uploadTagForKaltura,
                         mediaType, fileExtension, conversionProfileId);
-                log.info("Uploaded stream='{}' and got kalturaId='{}'", path, kalturaId);
+                log.info("Uploaded stream='{}' and got kalturaId='{}'", filePath, kalturaId);
                 //update storage record with kalturaId
                 updateKalturaIdForRecord(storageClient, fileId, kalturaId);
                 log.info("Updated Kaltura mapping in storage for fileId='{}'", fileId);
                 return 1;
             } catch (Exception e) {  //Stop delta job
-                log.error("Failed uploading stream to kaltura with fileId='{}', path='{}', title='{}', error='{}'", fileId, path, title, e.getMessage());
+                log.error("Failed uploading stream to kaltura with fileId='{}', path='{}', title='{}', error='{}'", fileId, filePath, title, e.getMessage());
                 updateKalturaIdForRecord(storageClient, fileId, StreamErrorTypeDto.API.getValue()); //Mark as API error
                 throw new InternalServiceException("Failed uploading stream to kaltura with fileId: " + fileId);
             }

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -114,7 +114,7 @@ public class KalturaDeltaUploadJob {
                     filePath = KalturaUtil.generateStreamPath(filePathSolr, originatesFrom, resourceDescription);
                 } catch (IOException e) {
                     String errorMessage = "Could not generate stream path";
-                    log.error(errorMessage, e);
+                    log.error(errorMessage);
                     throw new InternalServiceException(errorMessage, e);
                 }
 

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -51,30 +51,30 @@ public class KalturaDeltaUploadJob {
      *
      * <p>
      * 2) Calculate full path to the stream. Calculation depend on if record is DOMS or Preservica.
-     *    Validate file exists and not too short bytesize. If this happens mark the record with error and skip.
+     * Validate file exists and not too short bytesize. If this happens mark the record with error and skip.
      * <p>
-     *  3) Check that the file_id has not been uploaded to kaltura before. If it has use the kaltura internal id for this record.
+     * 3) Check that the file_id has not been uploaded to kaltura before. If it has use the kaltura internal id for this record.
      * <p>
      * 4) For each new stream:
      * <p>
-     *  4.1) Upload the stream to kaltura. (Notice some streams do not have extension, but this seems not to be an issue with kaltura). The kaltura 'tag'
-     *  for upload is 'delta-2025-05-01' where last part is current day. The kaltura tag-field is an internal kaltura field that we can use to see in which batch
-     *  the file was uploaded, and can also be used to search and delete all streams with this tag if something goes wrong.
+     * 4.1) Upload the stream to kaltura. (Notice some streams do not have extension, but this seems not to be an issue with kaltura). The kaltura 'tag'
+     * for upload is 'delta-2025-05-01' where last part is current day. The kaltura tag-field is an internal kaltura field that we can use to see in which batch
+     * the file was uploaded, and can also be used to search and delete all streams with this tag if something goes wrong.
      * <p>
-     *  4.2) Update the record's kalturaid in ds-storage
+     * 4.2) Update the record's kalturaid in ds-storage
      * <p>
      * All records that has been updated with error or kalturaId will have mTime updated to new value.
      * After completion the facade method will start a solr delta-index job.
      *
-     * @param mTimeFrom Upload all streams for records in solr with mTimeFrom higher than this value.
+     * @return number of streams uploaded
      * @throws InternalServiceException If any Solr or Kaltura call fails. Stop uploading more. Maybe allow single kaltura upload jobs to fail later.
      */
-    public static int uploadStreamsToKaltura() throws InternalServiceException{
+    public static int uploadStreamsToKaltura() throws InternalServiceException {
 
         boolean moreSolrRecords = true;
         long mTimeFromCurrent = 0; //Use this for batching. It will still only extract records without kaltura_id
-        Integer numberStreamsUploaded = 0;
-        String uploadTagForKaltura=getUploadTagForKaltura();
+        int numberStreamsUploaded = 0;
+        String uploadTagForKaltura = getUploadTagForKaltura();
         //The minimumFileSizeInBytesvalue has been defined by Asger+Petur. It has been burned into the kaltura bulk upload and must not be changed, unless we start with a new empty kaltura partnerid.
         //Next time I recommend a much higher value such as 4096 etc, this is a few seconds of audio.
         long minimumFileSizeInBytes = 700;
@@ -85,11 +85,11 @@ public class KalturaDeltaUploadJob {
             try {
                 SolrDocumentList docs = fetchSolrRecords(mTimeFromCurrent, 500);
                 if (docs.getNumFound() == 0) {
-                   return numberStreamsUploaded;
+                    return numberStreamsUploaded;
                 }
 
                 for (SolrDocument doc : docs) {
-                    String resourceDescription=(String) doc.getFieldValue("resource_description");
+                    String resourceDescription = (String) doc.getFieldValue("resource_description");
 
                     String title = "";//Default
                     ArrayList<String> titles = (ArrayList<String>) doc.getFieldValue("title"); //multivalue
@@ -98,7 +98,7 @@ public class KalturaDeltaUploadJob {
                     }
                     String description = (String) doc.getFieldValue("description");
                     String fileId = (String) doc.getFieldValue("file_id");
-                    String filePathSolr =(String) doc.getFieldValue("file_path");
+                    String filePathSolr = (String) doc.getFieldValue("file_path");
                     String originatesFrom = (String) doc.getFieldValue("originates_from");
                     String id = (String) doc.getFieldValue("id");
                     long recordMtime = (Long) doc.getFieldValue("internal_storage_mTime");
@@ -107,17 +107,17 @@ public class KalturaDeltaUploadJob {
                     String filePath = KalturaUtil.generateStreamPath(filePathSolr, originatesFrom, resourceDescription);
                     mTimeFromCurrent = recordMtime + 1L; //update mTime for next call
 
-                    if (recordAlreadyHasKalturaId(storageClient, id)){ // No need to ask kaltura for kalturaId.
-                      continue;
+                    if (recordAlreadyHasKalturaId(storageClient, id)) { // No need to ask kaltura for kalturaId.
+                        continue;
                     }
 
-                    processUpload(numberStreamsUploaded, uploadTagForKaltura, minimumFileSizeInBytes, storageClient,
+                    numberStreamsUploaded += processUpload(uploadTagForKaltura, minimumFileSizeInBytes, storageClient,
                             resourceDescription, title, description, fileId, id, filePath, fileExtension);
                 }
 
             } catch (SolrServerException | IOException e) {
                 // Can not fetch more records. Stop delta upload
-                moreSolrRecords=false;
+                moreSolrRecords = false;
                 log.error("Could not fetch more solr records from mTime={}", mTimeFromCurrent);
                 throw new InternalServiceException("Could not fetch more solr records from mTime: " + mTimeFromCurrent);
             }
@@ -125,51 +125,49 @@ public class KalturaDeltaUploadJob {
         return numberStreamsUploaded;
     }
 
-    /*
+    /**
      * Upload stream to kaltura. Will update storage record with error message or kaltura_id if success.
      * If uploaded succes will increase the numberOfStreamsUploaded variable
      *
-     */
-    private static void processUpload(Integer numberStreamsUploaded, String uploadTagForKaltura, long minimumFileSizeInBytes, DsStorageClient storageClient,
-            String resourceDescription, String title, String description, String fileId, String id, String path,
-                                      String fileExtension) {
+     * @return Number of streams uploaded (either 1 if stream uploaded or 0 if skipped)
+     **/
+    private static int processUpload(String uploadTagForKaltura, long minimumFileSizeInBytes, DsStorageClient storageClient,
+                                     String resourceDescription, String title, String description, String fileId, String id, String path,
+                                     String fileExtension) {
         try {
             //upload stream
             MediaType mediaType = KalturaUtil.getMediaType(resourceDescription);
             int conversionProfileId = KalturaUtil.getGetConversionProfileId(mediaType);
-            log.info("validating stream='{}' with title='{}'",path,title);
-            String fileError= hasStreamFileError(path, minimumFileSizeInBytes);
+            log.info("validating stream='{}' with title='{}'", path, title);
+            String fileError = hasStreamFileError(path, minimumFileSizeInBytes);
             if (fileError != null) {
                 log.warn("File does not exist='{}' or size in bytes less than '{}'. Error='{}'. Id='{}'. Skipping upload", path, minimumFileSizeInBytes, fileError, id);
                 updateKalturaIdForRecord(storageClient, fileId, fileError);
-                return;
+                return 0;
             }
 
             // Check file not already in kaltura. 
-            String kalturaInternalId=getInternalIdKaltura(fileId);
+            String kalturaInternalId = getInternalIdKaltura(fileId);
             if (kalturaInternalId != null) {
-                log.warn("Stream allready found in kaltura. FileId='{}' and has kalturaId='{}'. Setting this kalturaId for recordId='{}'", fileId, kalturaInternalId, id);
+                log.warn("Stream already found in Kaltura. FileId='{}' and has kalturaId='{}'. Setting this kalturaId for recordId='{}'", fileId, kalturaInternalId, id);
                 updateKalturaIdForRecord(storageClient, fileId, kalturaInternalId);
-                return;
+                return 0;
             }
 
             try {
-                String kalturaId=uploadStream(title, fileId, description, path, uploadTagForKaltura,
+                String kalturaId = uploadStream(title, fileId, description, path, uploadTagForKaltura,
                         mediaType, fileExtension, conversionProfileId);
                 log.info("Uploaded stream='{}' and got kalturaId='{}'", path, kalturaId);
-                numberStreamsUploaded++; //Success count
-                //update storage record with kalturaId                     
+                //update storage record with kalturaId
                 updateKalturaIdForRecord(storageClient, fileId, kalturaId);
-                log.info("Updated kaltura mapping in storage for fileId='{}'", fileId);
-                return;
-            }
-            catch(Exception e) {  //Stop delta job
+                log.info("Updated Kaltura mapping in storage for fileId='{}'", fileId);
+                return 1;
+            } catch (Exception e) {  //Stop delta job
                 log.error("Failed uploading stream to kaltura with fileId='{}', path='{}', title='{}', error='{}'", fileId, path, title, e.getMessage());
                 updateKalturaIdForRecord(storageClient, fileId, StreamErrorTypeDto.API.getValue()); //Mark as API error
                 throw new InternalServiceException("Failed uploading stream to kaltura with fileId: " + fileId);
             }
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             //Totally stop all uploads if a single call fails. Change strategy if this does seem to happen sporadic
             //Delta upload can be started again. We want to detect this error and not ignore it.
             log.error("Error kaltura lookup for fileId='{}'" + fileId, e);

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -1,16 +1,14 @@
 package dk.kb.datahandler.kaltura;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Locale;
-
+import com.kaltura.client.enums.MediaType;
 import com.kaltura.client.types.APIException;
+import dk.kb.datahandler.config.ServiceConfig;
+import dk.kb.kaltura.client.DsKalturaClient;
 import dk.kb.kaltura.enums.FileExtension;
+import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.StreamErrorTypeDto;
+import dk.kb.storage.util.DsStorageClient;
+import dk.kb.util.webservice.exception.InternalServiceException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -21,14 +19,14 @@ import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.kaltura.client.enums.MediaType;
-
-import dk.kb.datahandler.config.ServiceConfig;
-import dk.kb.kaltura.client.DsKalturaClient;
-import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.StreamErrorTypeDto;
-import dk.kb.storage.util.DsStorageClient;
-import dk.kb.util.webservice.exception.InternalServiceException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * This class has a single public method to upload all kaltura streams with from mTime (in Solr) and higher values.
@@ -132,8 +130,8 @@ public class KalturaDeltaUploadJob {
      * @return Number of streams uploaded (either 1 if stream uploaded or 0 if skipped)
      **/
     static int processUpload(String uploadTagForKaltura, long minimumFileSizeInBytes, DsStorageClient storageClient,
-                                     String resourceDescription, String title, String description, String fileId, String id, String path,
-                                     String fileExtension) {
+                             String resourceDescription, String title, String description, String fileId, String id, String path,
+                             String fileExtension) {
         try {
             //upload stream
             MediaType mediaType = KalturaUtil.getMediaType(resourceDescription);
@@ -181,7 +179,7 @@ public class KalturaDeltaUploadJob {
      * and searchable, check if record directly on the record.
      */
     static boolean recordAlreadyHasKalturaId(DsStorageClient storageClient, String recordId) {
-        DsRecordDto record = storageClient.getRecord(recordId,false);
+        DsRecordDto record = storageClient.getRecord(recordId, false);
         if (record.getKalturaId() != null) {
             log.info("Record already has kaltura id and no need to search in kaltura. Id='{}'", recordId);
             return true;
@@ -218,7 +216,7 @@ public class KalturaDeltaUploadJob {
             solrQuery.setQuery(query);
             solrQuery.setFilterQueries(filterQuery);
             solrQuery.set("facet", "false"); // very important. Must overwrite to false. Facets are very slow and expensive.
-            solrQuery.set("hl",false);// no highlights
+            solrQuery.set("hl", false);// no highlights
             solrQuery.set("spellcheck", false); //No spellcheck
             solrQuery.add("sort", "internal_storage_mTime ASC"); // increasing order
             solrQuery.add("fl", fieldList);
@@ -273,17 +271,16 @@ public class KalturaDeltaUploadJob {
     /**
      * This method is not called by the upload flow, but from the integration unittest.
      *
-     * @param  kalturaEntryId  The internal kaltura entryId
+     * @param kalturaEntryId The internal kaltura entryId
      * @throws APIException If API error
      */
     public static void deleteStream(String kalturaEntryId) throws APIException {
         initKalturaClient();
-        boolean deleteStreamByEntryId = kalturaClient.deleteStreamByEntryId( kalturaEntryId);
+        boolean deleteStreamByEntryId = kalturaClient.deleteStreamByEntryId(kalturaEntryId);
         if (deleteStreamByEntryId) {
-           log.info("Deleted kaltura entryId='{}'", kalturaEntryId);
-        }
-        else {
-           log.info("Failed deleting kaltura entryId='{}'", kalturaEntryId);
+            log.info("Deleted kaltura entryId='{}'", kalturaEntryId);
+        } else {
+            log.info("Failed deleting kaltura entryId='{}'", kalturaEntryId);
         }
     }
 
@@ -303,7 +300,7 @@ public class KalturaDeltaUploadJob {
 
         String kalturaInternalId = kalturaClient.getKalturaInternalId(file_id);
         if (kalturaInternalId != null) {
-            log.debug("Kaltura fileId='{}' is already in kaltura with entry_id='{}'",file_id,kalturaInternalId);
+            log.debug("Kaltura fileId='{}' is already in kaltura with entry_id='{}'", file_id, kalturaInternalId);
         }
         return kalturaInternalId;
     }
@@ -313,10 +310,10 @@ public class KalturaDeltaUploadJob {
      *
      */
     private static String getUploadTagForKaltura() {
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd",Locale.getDefault());
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
         String yyyyMMdd = formatter.format(new Date());
         String transcoded = "transcoded";
-        return "delta-"+yyyyMMdd + "," + transcoded;
+        return "delta-" + yyyyMMdd + "," + transcoded;
     }
 
     /**
@@ -328,27 +325,24 @@ public class KalturaDeltaUploadJob {
      * StreamErrorTypeDto.FILE_MISSING
      * <p>
      *
-     *
-     * @param filePath fill path to stream.
+     * @param filePath           fill path to stream.
      * @param minimumSizeInBytes minimum size in bytes allowed
-     *
-     * @return  StreamErrorTypeDto error or null if file exists has large enough.
+     * @return StreamErrorTypeDto error or null if file exists has large enough.
      *
      */
     static StreamErrorTypeDto hasStreamFileError(String filePath, long minimumSizeInBytes) {
         Path path = Paths.get(filePath);
-        if  (!Files.exists(path)){
+        if (!Files.exists(path)) {
             return StreamErrorTypeDto.FILE_MISSING;
         }
         long size = 0;
         try {
-            size= Files.size(path);
+            size = Files.size(path);
             if (size < minimumSizeInBytes) {
                 log.warn("File '{}' exists but below minimum bytesize, size='{}'", filePath, size);
                 return StreamErrorTypeDto.FILE_TOO_SHORT;
             }
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             return StreamErrorTypeDto.FILE_MISSING; //Can not happen, but need to return value.
         }
         log.debug("File '{}' exists and has size='{}'", filePath, size);
@@ -366,8 +360,8 @@ public class KalturaDeltaUploadJob {
         String userId = ServiceConfig.getKalturaUserId();
         String token = ServiceConfig.getKalturaToken();
         String tokenId = ServiceConfig.getKalturaTokenId();
-        int sessionDurationSeconds=ServiceConfig.getKalturaSessionDurationSeconds();
-        int sessionRefreshThreshold=ServiceConfig.getKalturaSessionRefreshThreshold();
+        int sessionDurationSeconds = ServiceConfig.getKalturaSessionDurationSeconds();
+        int sessionRefreshThreshold = ServiceConfig.getKalturaSessionRefreshThreshold();
         int conversionQueueThreshold = ServiceConfig.getConversionQueueThreshold();
         int conversionQueueDelaySeconds = ServiceConfig.getConversionQueueDelaySeconds();
 

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -355,7 +355,7 @@ public class KalturaDeltaUploadJob {
         }
 
         String kalturaUrl = ServiceConfig.getKalturaUrl();
-        Integer partnerId = ServiceConfig.getKalturaPartnerId();
+        int partnerId = ServiceConfig.getKalturaPartnerId();
         String adminSecret = null;// We use appTokens instead
         String userId = ServiceConfig.getKalturaUserId();
         String token = ServiceConfig.getKalturaToken();

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -168,7 +168,7 @@ public class KalturaDeltaUploadJob {
         } catch (Exception e) {
             //Totally stop all uploads if a single call fails. Change strategy if this does seem to happen sporadic
             //Delta upload can be started again. We want to detect this error and not ignore it.
-            log.error("Error kaltura lookup for fileId='{}'" + fileId, e);
+            log.error("Error kaltura lookup for fileId='{}'", fileId, e);
             //Do not mark record with error. We need to know why this happens.
             throw new InternalServiceException("Error kaltura lookup for fileId: " + fileId);
         }

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -35,7 +35,7 @@ import dk.kb.util.webservice.exception.InternalServiceException;
  */
 public class KalturaDeltaUploadJob {
 
-    private static DsKalturaClient kalturaClient = null;
+    static DsKalturaClient kalturaClient = null;
     private static final Logger log = LoggerFactory.getLogger(KalturaDeltaUploadJob.class);
 
     /**
@@ -131,7 +131,7 @@ public class KalturaDeltaUploadJob {
      *
      * @return Number of streams uploaded (either 1 if stream uploaded or 0 if skipped)
      **/
-    private static int processUpload(String uploadTagForKaltura, long minimumFileSizeInBytes, DsStorageClient storageClient,
+    static int processUpload(String uploadTagForKaltura, long minimumFileSizeInBytes, DsStorageClient storageClient,
                                      String resourceDescription, String title, String description, String fileId, String id, String path,
                                      String fileExtension) {
         try {
@@ -139,10 +139,10 @@ public class KalturaDeltaUploadJob {
             MediaType mediaType = KalturaUtil.getMediaType(resourceDescription);
             int conversionProfileId = KalturaUtil.getGetConversionProfileId(mediaType);
             log.info("validating stream='{}' with title='{}'", path, title);
-            String fileError = hasStreamFileError(path, minimumFileSizeInBytes);
+            StreamErrorTypeDto fileError = hasStreamFileError(path, minimumFileSizeInBytes);
             if (fileError != null) {
-                log.warn("File does not exist='{}' or size in bytes less than '{}'. Error='{}'. Id='{}'. Skipping upload", path, minimumFileSizeInBytes, fileError, id);
-                updateKalturaIdForRecord(storageClient, fileId, fileError);
+                log.warn("File does not exist='{}' or size in bytes less than '{}'. Error='{}'. Id='{}'. Skipping upload", path, minimumFileSizeInBytes, fileError.getValue(), id);
+                updateKalturaIdForRecord(storageClient, fileId, fileError.getValue());
                 return 0;
             }
 
@@ -180,7 +180,7 @@ public class KalturaDeltaUploadJob {
      * Bcause there is a delay in Kaltura when a record is upload and before it is indexed
      * and searchable, check if record directly on the record.
      */
-    private static boolean recordAlreadyHasKalturaId(DsStorageClient storageClient, String recordId) {
+    static boolean recordAlreadyHasKalturaId(DsStorageClient storageClient, String recordId) {
         DsRecordDto record = storageClient.getRecord(recordId,false);
         if (record.getKalturaId() != null) {
             log.info("Record already has kaltura id and no need to search in kaltura. Id='{}'", recordId);
@@ -189,7 +189,7 @@ public class KalturaDeltaUploadJob {
         return false;
     }
 
-    private static void updateKalturaIdForRecord(DsStorageClient storageClient, String fileId, String kalturaInternalId) {
+    static void updateKalturaIdForRecord(DsStorageClient storageClient, String fileId, String kalturaInternalId) {
         storageClient.updateKalturaIdForRecord(fileId, kalturaInternalId);
     }
 
@@ -297,7 +297,7 @@ public class KalturaDeltaUploadJob {
      * @throws APIException If API error
      *
      */
-    private static String getInternalIdKaltura(String file_id) throws IOException, APIException {
+    static String getInternalIdKaltura(String file_id) throws IOException, APIException {
 
         initKalturaClient();
 
@@ -335,27 +335,27 @@ public class KalturaDeltaUploadJob {
      * @return  StreamErrorTypeDto error or null if file exists has large enough.
      *
      */
-    private static String hasStreamFileError(String filePath,long minimumSizeInBytes) {
+    static StreamErrorTypeDto hasStreamFileError(String filePath, long minimumSizeInBytes) {
         Path path = Paths.get(filePath);
         if  (!Files.exists(path)){
-            return StreamErrorTypeDto.FILE_MISSING.getValue();
+            return StreamErrorTypeDto.FILE_MISSING;
         }
         long size = 0;
         try {
             size= Files.size(path);
             if (size < minimumSizeInBytes) {
                 log.warn("File '{}' exists but below minimum bytesize, size='{}'", filePath, size);
-                return StreamErrorTypeDto.FILE_TOO_SHORT.getValue();
+                return StreamErrorTypeDto.FILE_TOO_SHORT;
             }
         }
         catch(Exception e) {
-            return StreamErrorTypeDto.FILE_MISSING.getValue(); //Can not happen, but need to return value.
+            return StreamErrorTypeDto.FILE_MISSING; //Can not happen, but need to return value.
         }
         log.debug("File '{}' exists and has size='{}'", filePath, size);
         return null;
     }
 
-    private static void initKalturaClient() {
+    static void initKalturaClient() {
         if (kalturaClient != null) {
             return; // already inititalised
         }

--- a/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
+++ b/src/main/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadJob.java
@@ -80,44 +80,50 @@ public class KalturaDeltaUploadJob {
         DsStorageClient storageClient = new DsStorageClient(dsStorageUrl);
 
         while (moreSolrRecords) {
+            SolrDocumentList docs;
             try {
-                SolrDocumentList docs = fetchSolrRecords(mTimeFromCurrent, 500);
-                if (docs.getNumFound() == 0) {
-                    return numberStreamsUploaded;
-                }
-
-                for (SolrDocument doc : docs) {
-                    String resourceDescription = (String) doc.getFieldValue("resource_description");
-
-                    String title = "";//Default
-                    ArrayList<String> titles = (ArrayList<String>) doc.getFieldValue("title"); //multivalue
-                    if (titles != null && titles.size() > 0) {
-                        title = titles.get(0);// take first
-                    }
-                    String description = (String) doc.getFieldValue("description");
-                    String fileId = (String) doc.getFieldValue("file_id");
-                    String filePathSolr = (String) doc.getFieldValue("file_path");
-                    String originatesFrom = (String) doc.getFieldValue("originates_from");
-                    String id = (String) doc.getFieldValue("id");
-                    long recordMtime = (Long) doc.getFieldValue("internal_storage_mTime");
-                    String fileExtension = (String) doc.getFieldValue("file_extension");
-
-                    String filePath = KalturaUtil.generateStreamPath(filePathSolr, originatesFrom, resourceDescription);
-                    mTimeFromCurrent = recordMtime + 1L; //update mTime for next call
-
-                    if (recordAlreadyHasKalturaId(storageClient, id)) { // No need to ask kaltura for kalturaId.
-                        continue;
-                    }
-
-                    numberStreamsUploaded += processUpload(uploadTagForKaltura, minimumFileSizeInBytes, storageClient,
-                            resourceDescription, title, description, fileId, id, filePath, fileExtension);
-                }
-
+                docs = fetchSolrRecords(mTimeFromCurrent, 500);
             } catch (SolrServerException | IOException e) {
                 // Can not fetch more records. Stop delta upload
                 moreSolrRecords = false;
                 log.error("Could not fetch more solr records from mTime={}", mTimeFromCurrent);
-                throw new InternalServiceException("Could not fetch more solr records from mTime: " + mTimeFromCurrent);
+                throw new InternalServiceException(e.getMessage());
+            }
+            if (docs.getNumFound() == 0) {
+                return numberStreamsUploaded;
+            }
+
+            for (SolrDocument doc : docs) {
+                String resourceDescription = (String) doc.getFieldValue("resource_description");
+
+                String title = "";//Default
+                ArrayList<String> titles = (ArrayList<String>) doc.getFieldValue("title"); //multivalue
+                if (titles != null && titles.size() > 0) {
+                    title = titles.get(0);// take first
+                }
+                String description = (String) doc.getFieldValue("description");
+                String fileId = (String) doc.getFieldValue("file_id");
+                String filePathSolr = (String) doc.getFieldValue("file_path");
+                String originatesFrom = (String) doc.getFieldValue("originates_from");
+                String id = (String) doc.getFieldValue("id");
+                long recordMtime = (Long) doc.getFieldValue("internal_storage_mTime");
+                String fileExtension = (String) doc.getFieldValue("file_extension");
+                String filePath;
+                try{
+                    filePath = KalturaUtil.generateStreamPath(filePathSolr, originatesFrom, resourceDescription);
+                }catch (IOException e){
+                    log.error("Could not generate stream path");
+                    throw new InternalServiceException(e.getMessage());
+                }
+
+                mTimeFromCurrent = recordMtime + 1L; //update mTime for next call
+
+                if (recordAlreadyHasKalturaId(storageClient, id)) { // No need to ask kaltura for kalturaId.
+                    continue;
+                }
+
+                numberStreamsUploaded += processUpload(uploadTagForKaltura, minimumFileSizeInBytes, storageClient,
+                        resourceDescription, title, description, fileId, id, filePath, fileExtension);
             }
         }
         return numberStreamsUploaded;

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class KalturaDeltaUploadUnitTest {
     static MockedStatic<KalturaDeltaUploadJob> service;
-    private static final String UPLOAD_TAG = "test-upload-tag";
-    private static final long MIN_FILE_SIZE = 700L;
     private static final String FILE_ID = "file-123";
     private static final String RECORD_ID = "record-456";
     private static final String TITLE = "Test Stream Title";
@@ -32,8 +30,6 @@ class KalturaDeltaUploadUnitTest {
     private static final String FILE_PATH = "/streams/test/file.mp4";
     private static final String FILE_EXTENSION = "mp4";
     private static final String RESOURCE_DESCRIPTION = "video";
-    private static final String KALTURA_ID = "kaltura-789";
-
 
     @BeforeEach
     void initSetup() {
@@ -70,7 +66,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void testUploadStreamsToKaltura_whenRecordAlreadyHasKalturaId_thenSkipsRecord() {
+    void testUploadStreamsToKaltura_whenRecordAlreadyHasKalturaId_thenSkipRecord() {
         // Arrange
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList emptySolrDocumentList = new SolrDocumentList();
@@ -106,8 +102,7 @@ class KalturaDeltaUploadUnitTest {
 
         // Assert
         assertEquals(1, result);
-        service.verify(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()), atMostOnce());
-
+        service.verify(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()), times(1));
     }
 
     @Test
@@ -150,7 +145,8 @@ class KalturaDeltaUploadUnitTest {
 
         // Assert
         assertEquals(2, result);
-
+        service.verify(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(),
+                anyInt()), times(2));
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -159,30 +160,28 @@ class KalturaDeltaUploadUnitTest {
     }
 
     private SolrDocument buildSolrDocument(String id) {
-        SolrDocument doc = new SolrDocument();
-        doc.setField("id", id);
-        doc.setField("file_id", FILE_ID);
-        doc.setField("file_path", FILE_PATH);
-        doc.setField("file_extension", FILE_EXTENSION);
-        doc.setField("resource_description", RESOURCE_DESCRIPTION);
-        doc.setField("description", DESCRIPTION);
-        doc.setField("originates_from", KalturaUtil.ORGINATES_FROM.Preservica.name());
-        doc.setField("internal_storage_mTime", 1_700_000_000L);
+        SolrDocument solrDocument = new SolrDocument();
+        solrDocument.setField("id", id);
+        solrDocument.setField("file_id", FILE_ID);
+        solrDocument.setField("file_path", FILE_PATH);
+        solrDocument.setField("file_extension", FILE_EXTENSION);
+        solrDocument.setField("resource_description", RESOURCE_DESCRIPTION);
+        solrDocument.setField("description", DESCRIPTION);
+        solrDocument.setField("originates_from", KalturaUtil.ORGINATES_FROM.Preservica.name());
+        solrDocument.setField("internal_storage_mTime", 1_700_000_000L);
 
         ArrayList<String> titles = new ArrayList<>();
         titles.add(TITLE);
         titles.add("Secondary Title");
-        doc.setField("title", titles);
+        solrDocument.setField("title", titles);
 
-        return doc;
+        return solrDocument;
     }
 
     private SolrDocumentList buildSolrDocumentList(SolrDocument... documents) {
-        SolrDocumentList list = new SolrDocumentList();
-        for (SolrDocument doc : documents) {
-            list.add(doc);
-        }
-        list.setNumFound(documents.length);
-        return list;
+        SolrDocumentList solrDocumentList = new SolrDocumentList();
+        solrDocumentList.addAll(Arrays.asList(documents));
+        solrDocumentList.setNumFound(documents.length);
+        return solrDocumentList;
     }
 }

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -1,0 +1,176 @@
+package dk.kb.datahandler.kaltura;
+
+import dk.kb.util.webservice.exception.InternalServiceException;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KalturaDeltaUploadUnitTest {
+    static MockedStatic<KalturaDeltaUploadJob> service;
+    private static final String UPLOAD_TAG = "test-upload-tag";
+    private static final long MIN_FILE_SIZE = 700L;
+    private static final String FILE_ID = "file-123";
+    private static final String RECORD_ID = "record-456";
+    private static final String TITLE = "Test Stream Title";
+    private static final String DESCRIPTION = "Test Description";
+    private static final String FILE_PATH = "/streams/test/file.mp4";
+    private static final String FILE_EXTENSION = "mp4";
+    private static final String RESOURCE_DESCRIPTION = "video";
+    private static final String KALTURA_ID = "kaltura-789";
+
+
+    @BeforeAll
+    static void initSetup() {
+        service = mockStatic(KalturaDeltaUploadJob.class, CALLS_REAL_METHODS);
+//        service.when(KalturaDeltaUploadJob::initKalturaClient).then((Answer<?>) (KalturaDeltaUploadJob.kalturaClient = mock(DsKalturaClient.class)));
+    }
+
+    @BeforeEach
+    void setUp() {
+        service.when(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(),any(), anyInt()))
+                .thenReturn("0_test");
+        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any())).thenAnswer(inv -> null);
+    }
+
+    // ─── uploadStreamsToKaltura ───────────────────────────────────────────────
+
+    @Test
+    void uploadStreamsToKaltura_returnsZero_whenSolrHasNoDocuments(){
+
+        SolrDocumentList emptyList = new SolrDocumentList(); // numFound = 0
+
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenReturn(emptyList);
+
+        int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    void uploadStreamsToKaltura_skipsRecord_whenAlreadyHasKalturaId(){
+        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument(), buildSolrDocument());
+        SolrDocumentList empty = new SolrDocumentList();
+
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenReturn(docs, empty);
+        service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
+                .thenReturn(true);
+
+        int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
+
+        assertEquals(0, result);
+        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(), any(), any(), any(), any()), never());
+
+    }
+
+    @Test
+    void uploadStreamsToKaltura_countsUploadedStreams_whenProcessUploadSucceeds() {
+        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument());
+        SolrDocumentList empty = new SolrDocumentList();
+
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenReturn(docs, empty);
+        service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
+                .thenReturn(false);
+        service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
+        service.when(() -> KalturaDeltaUploadJob.hasStreamFileError(anyString(), anyLong())).thenReturn(null);
+        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any()))
+                .thenAnswer(inv -> null);
+
+        int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
+
+        assertEquals(1, result);
+
+    }
+
+    @Test
+    void uploadStreamsToKaltura_throwsInternalServiceException_onSolrServerException() {
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenThrow(new SolrServerException("Solr is down"));
+
+        assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
+
+    }
+
+    @Test
+    void uploadStreamsToKaltura_throwsInternalServiceException_onIOException() {
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenThrow(new IOException("Network failure"));
+
+        assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
+
+    }
+
+    @Test
+    void uploadStreamsToKaltura_accumulatesCount_acrossMultipleDocuments() {
+        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument("id-1"), buildSolrDocument("id-2"));
+        SolrDocumentList empty = new SolrDocumentList();
+
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenReturn(docs)
+                .thenReturn(empty);
+        service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), anyString())).thenReturn(false);
+        service.when(() -> KalturaDeltaUploadJob.processUpload(anyString(), anyLong(), any(), anyString(), anyString(),
+                anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(1);
+        service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
+        service.when(() -> KalturaDeltaUploadJob.uploadStream(anyString(), anyString(), anyString(), anyString(), anyString(), any(), anyString(), anyInt()))
+                .thenReturn("0_testiness0");
+
+        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any()))
+                .thenAnswer(inv -> null);
+
+        int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
+
+        assertEquals(2, result);
+
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private SolrDocument buildSolrDocument() {
+        return buildSolrDocument(RECORD_ID);
+    }
+
+    private SolrDocument buildSolrDocument(String id) {
+        SolrDocument doc = new SolrDocument();
+        doc.setField("id", id);
+        doc.setField("file_id", FILE_ID);
+        doc.setField("file_path", FILE_PATH);
+        doc.setField("file_extension", FILE_EXTENSION);
+        doc.setField("resource_description", RESOURCE_DESCRIPTION);
+        doc.setField("description", DESCRIPTION);
+        doc.setField("originates_from", KalturaUtil.ORGINATES_FROM.Preservica.name());
+        doc.setField("internal_storage_mTime", 1_700_000_000L);
+
+        ArrayList<String> titles = new ArrayList<>();
+        titles.add(TITLE);
+        titles.add("Secondary Title");
+        doc.setField("title", titles);
+
+        return doc;
+    }
+
+    private SolrDocumentList buildSolrDocumentList(SolrDocument... documents) {
+        SolrDocumentList list = new SolrDocumentList();
+        for (SolrDocument doc : documents) {
+            list.add(doc);
+        }
+        list.setNumFound(documents.length);
+        return list;
+    }
+}

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -72,9 +72,9 @@ class KalturaDeltaUploadUnitTest {
     void testUploadStreamsToKaltura_whenRecordAlreadyHasKalturaId_thenSkipsRecord() {
         // Arrange
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
-        SolrDocumentList empty = new SolrDocumentList();
+        SolrDocumentList emptySolrDocumentList = new SolrDocumentList();
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(solrDocumentList, empty);
+                .thenReturn(solrDocumentList, emptySolrDocumentList);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(true);
 
@@ -91,10 +91,10 @@ class KalturaDeltaUploadUnitTest {
     void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountUploadedStreams() {
         // Arrange
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
-        SolrDocumentList empty = new SolrDocumentList();
+        SolrDocumentList emptySolrDocumentList = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(solrDocumentList, empty);
+                .thenReturn(solrDocumentList, emptySolrDocumentList);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(false);
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
@@ -135,11 +135,11 @@ class KalturaDeltaUploadUnitTest {
     void testUploadStreamsToKaltura_whenMultipleDocuments_thenAccumulatesCount() {
 
         // Arrange
-        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument("id-1"), buildSolrDocument("id-2"));
-        SolrDocumentList empty = new SolrDocumentList();
+        SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument("id-1"), buildSolrDocument("id-2"));
+        SolrDocumentList emptySolrDocumentList = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(docs, empty);
+                .thenReturn(solrDocumentList, emptySolrDocumentList);
         service.when(() -> KalturaDeltaUploadJob.hasStreamFileError(anyString(), anyLong())).thenReturn(null);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), anyString())).thenReturn(false);
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -131,6 +131,7 @@ class KalturaDeltaUploadUnitTest {
 
     @Test
     void testUploadStreamsToKaltura_CreateStreamPathonIOException_thenThrowsInternalServiceException() {
+        // Arrange
         String expectedMessage = "Could not find a valid streamPath for that input";
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList emptySolrDocumentList = new SolrDocumentList();

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -14,7 +14,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -41,7 +42,7 @@ class KalturaDeltaUploadUnitTest {
 
     @BeforeEach
     void setUp() {
-        service.when(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(),any(), anyInt()))
+        service.when(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn("0_test");
         service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any())).thenAnswer(inv -> null);
     }
@@ -49,7 +50,7 @@ class KalturaDeltaUploadUnitTest {
     // ─── uploadStreamsToKaltura ───────────────────────────────────────────────
 
     @Test
-    void uploadStreamsToKaltura_returnsZero_whenSolrHasNoDocuments(){
+    void uploadStreamsToKaltura_returnsZero_whenSolrHasNoDocuments() {
 
         SolrDocumentList emptyList = new SolrDocumentList(); // numFound = 0
 
@@ -62,7 +63,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void uploadStreamsToKaltura_skipsRecord_whenAlreadyHasKalturaId(){
+    void uploadStreamsToKaltura_skipsRecord_whenAlreadyHasKalturaId() {
         SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument(), buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -108,23 +108,25 @@ class KalturaDeltaUploadUnitTest {
     @Test
     void testUploadStreamsToKaltura_onSolrServerException_thenThrowsInternalServiceException() {
         // Arrange
+        String expectedMessage = "Solr is down";
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenThrow(new SolrServerException("Solr is down"));
+                .thenThrow(new SolrServerException(expectedMessage));
 
         // Act and Assert
-        assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
-
+        Exception exception = assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test
     void testUploadStreamsToKaltura_onIOException_thenThrowsInternalServiceException() {
         // Arrange
+        String expectedMessage = "Network failure";
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenThrow(new IOException("Network failure"));
+                .thenThrow(new IOException(expectedMessage));
 
         // Act and Assert
-        assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
-
+        Exception exception = assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -4,12 +4,12 @@ import dk.kb.util.webservice.exception.InternalServiceException;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.verification.VerificationMode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,14 +34,19 @@ class KalturaDeltaUploadUnitTest {
     private static final String KALTURA_ID = "kaltura-789";
 
 
-    @BeforeAll
-    static void initSetup() {
+    @BeforeEach
+    void initSetup() {
         service = mockStatic(KalturaDeltaUploadJob.class, CALLS_REAL_METHODS);
         service.when(() -> KalturaDeltaUploadJob.initKalturaClient()).then(inv -> null);
         service.when(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn("0_test");
         service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any()))
                 .thenAnswer(inv -> null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.close();
     }
 
     // ─── uploadStreamsToKaltura ───────────────────────────────────────────────
@@ -58,8 +63,8 @@ class KalturaDeltaUploadUnitTest {
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
         // Assert
-        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
-                any(), any(), any(), any()), never());
+        service.verify(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(),
+                anyInt()), never());
         assertEquals(0, result);
     }
 
@@ -78,8 +83,8 @@ class KalturaDeltaUploadUnitTest {
 
         // Assert
         assertEquals(0, result);
-        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
-                any(), any(), any(), any()), never());
+        service.verify(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(),
+                anyInt()), never());
     }
 
     @Test
@@ -100,8 +105,7 @@ class KalturaDeltaUploadUnitTest {
 
         // Assert
         assertEquals(1, result);
-        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(), any(),
-                any(), any(), any()), atLeastOnce());
+        service.verify(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()), atMostOnce());
 
     }
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -39,13 +39,14 @@ class KalturaDeltaUploadUnitTest {
         service.when(() -> KalturaDeltaUploadJob.initKalturaClient()).then(inv -> null);
         service.when(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn("0_test");
-        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any())).thenAnswer(inv -> null);
+        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any()))
+                .thenAnswer(inv -> null);
     }
 
     // ─── uploadStreamsToKaltura ───────────────────────────────────────────────
 
     @Test
-    void uploadStreamsToKaltura_returnsZero_whenSolrHasNoDocuments() {
+    void testUploadStreamsToKaltura_whenSolrHasNoDocuments_thenReturnsZero_() {
 
         SolrDocumentList emptyList = new SolrDocumentList(); // numFound = 0
 
@@ -58,7 +59,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void uploadStreamsToKaltura_skipsRecord_whenAlreadyHasKalturaId() {
+    void testUploadStreamsToKaltura_whenAlreadyHasKalturaId_thenSkipsRecord_() {
         SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument(), buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
@@ -70,12 +71,13 @@ class KalturaDeltaUploadUnitTest {
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
         assertEquals(0, result);
-        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(), any(), any(), any(), any()), never());
+        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
+                any(), any(), any(), any()), never());
 
     }
 
     @Test
-    void uploadStreamsToKaltura_countsUploadedStreams_whenProcessUploadSucceeds() {
+    void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountsUploadedStreams() {
         SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
@@ -95,7 +97,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void uploadStreamsToKaltura_throwsInternalServiceException_onSolrServerException() {
+    void testUploadStreamsToKaltura_onSolrServerException_thenThrowsInternalServiceException() {
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
                 .thenThrow(new SolrServerException("Solr is down"));
 
@@ -104,7 +106,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void uploadStreamsToKaltura_throwsInternalServiceException_onIOException() {
+    void testUploadStreamsToKaltura_onIOException_thenThrowsInternalServiceException() {
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
                 .thenThrow(new IOException("Network failure"));
 
@@ -113,7 +115,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void uploadStreamsToKaltura_accumulatesCount_acrossMultipleDocuments() {
+    void testUploadStreamsToKaltura_whenMultipleDocuments_thenAccumulatesCount() {
         SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument("id-1"), buildSolrDocument("id-2"));
         SolrDocumentList empty = new SolrDocumentList();
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -5,7 +5,6 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
@@ -37,11 +36,7 @@ class KalturaDeltaUploadUnitTest {
     @BeforeAll
     static void initSetup() {
         service = mockStatic(KalturaDeltaUploadJob.class, CALLS_REAL_METHODS);
-//        service.when(KalturaDeltaUploadJob::initKalturaClient).then((Answer<?>) (KalturaDeltaUploadJob.kalturaClient = mock(DsKalturaClient.class)));
-    }
-
-    @BeforeEach
-    void setUp() {
+        service.when(() -> KalturaDeltaUploadJob.initKalturaClient()).then(inv -> null);
         service.when(() -> KalturaDeltaUploadJob.uploadStream(any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn("0_test");
         service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any())).thenAnswer(inv -> null);
@@ -123,17 +118,10 @@ class KalturaDeltaUploadUnitTest {
         SolrDocumentList empty = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(docs)
-                .thenReturn(empty);
+                .thenReturn(docs, empty);
+        service.when(() -> KalturaDeltaUploadJob.hasStreamFileError(anyString(), anyLong())).thenReturn(null);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), anyString())).thenReturn(false);
-        service.when(() -> KalturaDeltaUploadJob.processUpload(anyString(), anyLong(), any(), anyString(), anyString(),
-                anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(1);
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
-        service.when(() -> KalturaDeltaUploadJob.uploadStream(anyString(), anyString(), anyString(), anyString(), anyString(), any(), anyString(), anyInt()))
-                .thenReturn("0_testiness0");
-
-        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any()))
-                .thenAnswer(inv -> null);
 
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -48,14 +48,16 @@ class KalturaDeltaUploadUnitTest {
 
     @Test
     void testUploadStreamsToKaltura_whenSolrHasNoDocuments_thenNoRecordIsUploadedToKaltura() {
-
+        // Arrange
         SolrDocumentList emptySolrDocumentList = new SolrDocumentList(); // numFound = 0
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
                 .thenReturn(emptySolrDocumentList);
 
+        // Act
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
+        // Assert
         service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
                 any(), any(), any(), any()), never());
         assertEquals(0, result);
@@ -63,16 +65,18 @@ class KalturaDeltaUploadUnitTest {
 
     @Test
     void testUploadStreamsToKaltura_whenRecordAlreadyHasKalturaId_thenSkipsRecord() {
+        // Arrange
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
-
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
                 .thenReturn(solrDocumentList, empty);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(true);
 
+        // Act
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
+        // Assert
         assertEquals(0, result);
         service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
                 any(), any(), any(), any()), never());
@@ -80,6 +84,7 @@ class KalturaDeltaUploadUnitTest {
 
     @Test
     void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountUploadedStreams() {
+        // Arrange
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
@@ -90,8 +95,10 @@ class KalturaDeltaUploadUnitTest {
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
         service.when(() -> KalturaDeltaUploadJob.hasStreamFileError(anyString(), anyLong())).thenReturn(null);
 
+        // Act
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
+        // Assert
         assertEquals(1, result);
         service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(), any(),
                 any(), any(), any()), atLeastOnce());
@@ -100,24 +107,30 @@ class KalturaDeltaUploadUnitTest {
 
     @Test
     void testUploadStreamsToKaltura_onSolrServerException_thenThrowsInternalServiceException() {
+        // Arrange
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
                 .thenThrow(new SolrServerException("Solr is down"));
 
+        // Act and Assert
         assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
 
     }
 
     @Test
     void testUploadStreamsToKaltura_onIOException_thenThrowsInternalServiceException() {
+        // Arrange
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
                 .thenThrow(new IOException("Network failure"));
 
+        // Act and Assert
         assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
 
     }
 
     @Test
     void testUploadStreamsToKaltura_whenMultipleDocuments_thenAccumulatesCount() {
+
+        // Arrange
         SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument("id-1"), buildSolrDocument("id-2"));
         SolrDocumentList empty = new SolrDocumentList();
 
@@ -127,8 +140,10 @@ class KalturaDeltaUploadUnitTest {
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), anyString())).thenReturn(false);
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
 
+        // Act
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
+        // Assert
         assertEquals(2, result);
 
     }

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -139,7 +139,6 @@ class KalturaDeltaUploadUnitTest {
                 .thenReturn(solrDocumentList, emptySolrDocumentList);
 
         try (MockedStatic<KalturaUtil> kalturaUtilMock = mockStatic(KalturaUtil.class)) {
-            // Arrange
             kalturaUtilMock.when(() -> KalturaUtil.generateStreamPath(any(), any(), any()))
                     .thenThrow(new IOException(expectedMessage));
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,25 +47,27 @@ class KalturaDeltaUploadUnitTest {
     // ─── uploadStreamsToKaltura ───────────────────────────────────────────────
 
     @Test
-    void testUploadStreamsToKaltura_whenSolrHasNoDocuments_thenReturnsZero_() {
+    void testUploadStreamsToKaltura_whenSolrHasNoDocuments_thenNoRecordIsUploadedToKaltura() {
 
-        SolrDocumentList emptyList = new SolrDocumentList(); // numFound = 0
+        SolrDocumentList emptySolrDocumentList = new SolrDocumentList(); // numFound = 0
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(emptyList);
+                .thenReturn(emptySolrDocumentList);
 
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
+        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
+                any(), any(), any(), any()), never());
         assertEquals(0, result);
     }
 
     @Test
-    void testUploadStreamsToKaltura_whenAlreadyHasKalturaId_thenSkipsRecord_() {
-        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument(), buildSolrDocument());
+    void testUploadStreamsToKaltura_whenRecordAlreadyHasKalturaId_thenSkipsRecord() {
+        SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(docs, empty);
+                .thenReturn(solrDocumentList, empty);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(true);
 
@@ -73,26 +76,25 @@ class KalturaDeltaUploadUnitTest {
         assertEquals(0, result);
         service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
                 any(), any(), any(), any()), never());
-
     }
 
     @Test
-    void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountsUploadedStreams() {
-        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument());
+    void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountUploadedStreams() {
+        SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(docs, empty);
+                .thenReturn(solrDocumentList, empty);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(false);
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
         service.when(() -> KalturaDeltaUploadJob.hasStreamFileError(anyString(), anyLong())).thenReturn(null);
-        service.when(() -> KalturaDeltaUploadJob.updateKalturaIdForRecord(any(), any(), any()))
-                .thenAnswer(inv -> null);
 
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
         assertEquals(1, result);
+        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(), any(),
+                any(), any(), any()), atLeastOnce());
 
     }
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -106,7 +106,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void testUploadStreamsToKaltura_onSolrServerException_thenThrowsInternalServiceException() {
+    void testUploadStreamsToKaltura_whenFetchSolrRecordsThrowsSolrServerException_thenThrowsInternalServiceException() {
         // Arrange
         String expectedMessage = "Solr is down";
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
@@ -114,11 +114,11 @@ class KalturaDeltaUploadUnitTest {
 
         // Act and Assert
         Exception exception = assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
-        assertEquals(expectedMessage, exception.getMessage());
+        assertEquals(expectedMessage, exception.getCause().getMessage());
     }
 
     @Test
-    void testUploadStreamsToKaltura_onIOException_thenThrowsInternalServiceException() {
+    void testUploadStreamsToKaltura_whenFetchSolrRecordsThrowsIOException_thenThrowsInternalServiceException() {
         // Arrange
         String expectedMessage = "Network failure";
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
@@ -126,8 +126,28 @@ class KalturaDeltaUploadUnitTest {
 
         // Act and Assert
         Exception exception = assertThrows(InternalServiceException.class, KalturaDeltaUploadJob::uploadStreamsToKaltura);
-        assertEquals(expectedMessage, exception.getMessage());
+        assertEquals(expectedMessage, exception.getCause().getMessage());
     }
+
+    @Test
+    void testUploadStreamsToKaltura_CreateStreamPathonIOException_thenThrowsInternalServiceException() {
+        String expectedMessage = "Could not find a valid streamPath for that input";
+        SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
+        SolrDocumentList emptySolrDocumentList = new SolrDocumentList();
+        service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
+                .thenReturn(solrDocumentList, emptySolrDocumentList);
+
+        try (MockedStatic<KalturaUtil> kalturaUtilMock = mockStatic(KalturaUtil.class)) {
+            // Arrange
+            kalturaUtilMock.when(() -> KalturaUtil.generateStreamPath(any(), any(), any()))
+                    .thenThrow(new IOException(expectedMessage));
+
+            // Act and Assert
+            Exception exception = assertThrows(InternalServiceException.class, () -> KalturaDeltaUploadJob.uploadStreamsToKaltura());
+            assertEquals(expectedMessage, exception.getCause().getMessage());
+        }
+    }
+
 
     @Test
     void testUploadStreamsToKaltura_whenMultipleDocuments_thenAccumulatesCount() {

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,25 +47,27 @@ class KalturaDeltaUploadUnitTest {
     // ─── uploadStreamsToKaltura ───────────────────────────────────────────────
 
     @Test
-    void testUploadStreamsToKaltura_whenSolrHasNoDocuments_thenReturnsZero_() {
+    void testUploadStreamsToKaltura_whenSolrHasNoDocuments_thenNoRecordIsUploadedToKaltura() {
 
-        SolrDocumentList emptyList = new SolrDocumentList(); // numFound = 0
+        SolrDocumentList emptySolrDocumentList = new SolrDocumentList(); // numFound = 0
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(emptyList);
+                .thenReturn(emptySolrDocumentList);
 
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
+        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
+                any(), any(), any(), any()), never());
         assertEquals(0, result);
     }
 
     @Test
-    void testUploadStreamsToKaltura_whenAlreadyHasKalturaId_thenSkipsRecord_() {
-        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument(), buildSolrDocument());
+    void testUploadStreamsToKaltura_whenRecordAlreadyHasKalturaId_thenSkipsRecord() {
+        SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(docs, empty);
+                .thenReturn(solrDocumentList, empty);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(true);
 
@@ -73,16 +76,15 @@ class KalturaDeltaUploadUnitTest {
         assertEquals(0, result);
         service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(),
                 any(), any(), any(), any()), never());
-
     }
 
     @Test
-    void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountsUploadedStreams() {
-        SolrDocumentList docs = buildSolrDocumentList(buildSolrDocument());
+    void testUploadStreamsToKaltura_whenProcessUploadSucceeds_thenCountUploadedStreams() {
+        SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
         SolrDocumentList empty = new SolrDocumentList();
 
         service.when(() -> KalturaDeltaUploadJob.fetchSolrRecords(anyLong(), anyInt()))
-                .thenReturn(docs, empty);
+                .thenReturn(solrDocumentList, empty);
         service.when(() -> KalturaDeltaUploadJob.recordAlreadyHasKalturaId(any(), eq(RECORD_ID)))
                 .thenReturn(false);
         service.when(() -> KalturaDeltaUploadJob.getInternalIdKaltura(anyString())).thenReturn(null);
@@ -93,6 +95,8 @@ class KalturaDeltaUploadUnitTest {
         int result = KalturaDeltaUploadJob.uploadStreamsToKaltura();
 
         assertEquals(1, result);
+        service.verify(() -> KalturaDeltaUploadJob.processUpload(any(), anyLong(), any(), any(), any(), any(), any(),
+                any(), any(), any()), atLeastOnce());
 
     }
 

--- a/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
+++ b/src/test/java/dk/kb/datahandler/kaltura/KalturaDeltaUploadUnitTest.java
@@ -130,7 +130,7 @@ class KalturaDeltaUploadUnitTest {
     }
 
     @Test
-    void testUploadStreamsToKaltura_CreateStreamPathonIOException_thenThrowsInternalServiceException() {
+    void testUploadStreamsToKaltura_whenGenerateStreamPathThrowsIOException_thenThrowsInternalServiceException() {
         // Arrange
         String expectedMessage = "Could not find a valid streamPath for that input";
         SolrDocumentList solrDocumentList = buildSolrDocumentList(buildSolrDocument());
@@ -147,7 +147,6 @@ class KalturaDeltaUploadUnitTest {
             assertEquals(expectedMessage, exception.getCause().getMessage());
         }
     }
-
 
     @Test
     void testUploadStreamsToKaltura_whenMultipleDocuments_thenAccumulatesCount() {


### PR DESCRIPTION
Changed processUpload to return number of streams uploaded (1 or 0) and removed the numberStreamsUploaded arg. uploadStreamsToKaltura now keeps track of the count of streams uploaded instead of trying to pass the var to processUpload to be updated. 
Also made small changes to log messages spelling and auto-formatted the section of code i worked on.